### PR TITLE
Refactor cms await

### DIFF
--- a/api/cmsRoute.js
+++ b/api/cmsRoute.js
@@ -141,265 +141,272 @@ module.exports = function(app) {
     res.json(cmsCheck());
   });
 
-  app.get("/api/cms/tree", (req, res) => {
-    db.profiles.findAll(profileReqTreeOnly).then(profiles => {
-      profiles = sortProfileTree(profiles);
-      res.json(profiles);
-    });
+  app.get("/api/cms/tree", async(req, res) => {
+    let profiles = await db.profiles.findAll(profileReqTreeOnly);
+    profiles = sortProfileTree(profiles);
+    res.json(profiles);
   });
 
-  app.get("/api/cms/storytree", (req, res) => {
-    db.stories.findAll(storyReqTreeOnly).then(stories => {
-      stories = sortStoryTree(stories);
-      res.json(stories);
-    });
+  app.get("/api/cms/storytree", async(req, res) => {
+    let stories = await db.stories.findAll(storyReqTreeOnly);
+    stories = sortStoryTree(stories);
+    res.json(stories);
   });
 
-  app.get("/api/cms/profile/get/:id", (req, res) => {
+  app.get("/api/cms/profile/get/:id", async(req, res) => {
     const {id} = req.params;
     const reqObj = Object.assign({}, profileReqProfileOnly, {where: {id}});
-    db.profiles.findOne(reqObj).then(profile => {
-      res.json(sortProfile(profile));
-    });
+    const profile = await db.profiles.findOne(reqObj);
+    res.json(sortProfile(profile));
   });
 
-  app.get("/api/cms/story/get/:id", (req, res) => {
+  app.get("/api/cms/story/get/:id", async(req, res) => {
     const {id} = req.params;
     const reqObj = Object.assign({}, storyReqStoryOnly, {where: {id}});
-    db.stories.findOne(reqObj).then(story => {
-      res.json(sortStory(story));
-    });
+    const story = await db.stories.findOne(reqObj);
+    res.json(sortStory(story));
   });
 
-  app.get("/api/cms/section/get/:id", (req, res) => {
+  app.get("/api/cms/section/get/:id", async(req, res) => {
     const {id} = req.params;
     const reqObj = Object.assign({}, sectionReqSectionOnly, {where: {id}});
-    db.sections.findOne(reqObj).then(section => {
-      res.json(sortSection(section));
-    });
+    const section = await db.sections.findOne(reqObj);
+    res.json(sortSection(section));
   });
 
-  app.get("/api/cms/topic/get/:id", (req, res) => {
+  app.get("/api/cms/topic/get/:id", async(req, res) => {
     const {id} = req.params;
     const reqObj = Object.assign({}, topicReqTopicOnly, {where: {id}});
-    db.topics.findOne(reqObj).then(topic => {
-      const topicTypes = [];
-      shell.ls(`${topicTypeDir}*.jsx`).forEach(file => {
-        const compName = file.replace(topicTypeDir, "").replace(".jsx", "");
-        topicTypes.push(compName);
-      });
-      topic = sortTopic(topic);
-      topic.types = topicTypes;
-      res.json(topic);
+    let topic = await db.topics.findOne(reqObj);
+    const topicTypes = [];
+    shell.ls(`${topicTypeDir}*.jsx`).forEach(file => {
+      const compName = file.replace(topicTypeDir, "").replace(".jsx", "");
+      topicTypes.push(compName);
     });
+    topic = sortTopic(topic);
+    topic.types = topicTypes;
+    res.json(topic);
   });
 
-  app.get("/api/cms/storytopic/get/:id", (req, res) => {
+  app.get("/api/cms/storytopic/get/:id", async(req, res) => {
     const {id} = req.params;
     const reqObj = Object.assign({}, storyTopicReqStoryTopicOnly, {where: {id}});
-    db.storytopics.findOne(reqObj).then(storytopic => {
-      const topicTypes = [];
-      shell.ls(`${topicTypeDir}*.jsx`).forEach(file => {
-        const compName = file.replace(topicTypeDir, "").replace(".jsx", "");
-        topicTypes.push(compName);
-      });
-      storytopic = sortStoryTopic(storytopic);
-      storytopic.types = topicTypes;
-      res.json(storytopic);
+    let storytopic = await db.storytopics.findOne(reqObj);
+    const topicTypes = [];
+    shell.ls(`${topicTypeDir}*.jsx`).forEach(file => {
+      const compName = file.replace(topicTypeDir, "").replace(".jsx", "");
+      topicTypes.push(compName);
     });
+    storytopic = sortStoryTopic(storytopic);
+    storytopic.types = topicTypes;
+    res.json(storytopic);
   });
 
-  app.get("/api/cms/generator/get/:id", (req, res) => {
-    db.generators.findOne({where: {id: req.params.id}}).then(u => res.json(u));
+  app.get("/api/cms/generator/get/:id", async(req, res) => {
+    const u = await db.generators.findOne({where: {id: req.params.id}});
+    res.json(u);
   });
 
-  app.get("/api/cms/materializer/get/:id", (req, res) => {
-    db.materializers.findOne({where: {id: req.params.id}}).then(u => res.json(u));
+  app.get("/api/cms/materializer/get/:id", async(req, res) => {
+    const u = await db.materializers.findOne({where: {id: req.params.id}});
+    res.json(u);
   });
 
-  app.get("/api/cms/profile_stat/get/:id", (req, res) => {
-    db.profiles_stats.findOne({where: {id: req.params.id}}).then(u => res.json(u));
+  app.get("/api/cms/profile_stat/get/:id", async(req, res) => {
+    const u = await db.profiles_stats.findOne({where: {id: req.params.id}});
+    res.json(u);
   });
 
-  app.get("/api/cms/profile_visualization/get/:id", (req, res) => {
-    db.profiles_visualizations
-      .findOne({where: {id: req.params.id}})
-      .then(u => res.json(u));
+  app.get("/api/cms/profile_visualization/get/:id", async(req, res) => {
+    const u = await db.profiles_visualizations.findOne({where: {id: req.params.id}});
+    res.json(u);
   });
 
-  app.get("/api/cms/profile_description/get/:id", (req, res) => {
-    db.profiles_descriptions.findOne({where: {id: req.params.id}}).then(u => res.json(u));
+  app.get("/api/cms/profile_description/get/:id", async(req, res) => {
+    const u = await db.profiles_descriptions.findOne({where: {id: req.params.id}});
+    res.json(u);
   });
 
-  app.get("/api/cms/story_description/get/:id", (req, res) => {
-    db.stories_descriptions.findOne({where: {id: req.params.id}}).then(u => res.json(u));
+  app.get("/api/cms/story_description/get/:id", async(req, res) => {
+    const u = await db.stories_descriptions.findOne({where: {id: req.params.id}});
+    res.json(u);
   });
 
   // not sure if we need this - will footnote editing be a singular list, therefore not requiring piecemeal gets?
-  app.get("/api/cms/story_footnote/get/:id", (req, res) => {
-    db.stories_footnotes.findOne({where: {id: req.params.id}}).then(u => res.json(u));
+  app.get("/api/cms/story_footnote/get/:id", async(req, res) => {
+    const u = await db.stories_footnotes.findOne({where: {id: req.params.id}});
+    res.json(u);
   });
 
-  app.get("/api/cms/author/get/:id", (req, res) => {
-    db.authors.findOne({where: {id: req.params.id}}).then(u => res.json(u));
+  app.get("/api/cms/author/get/:id", async(req, res) => {
+    const u = await db.authors.findOne({where: {id: req.params.id}});
+    res.json(u);
   });
 
-  app.get("/api/cms/section_subtitle/get/:id", (req, res) => {
-    db.sections_subtitles.findOne({where: {id: req.params.id}}).then(u => res.json(u));
+  app.get("/api/cms/section_subtitle/get/:id", async(req, res) => {
+    const u = await db.sections_subtitles.findOne({where: {id: req.params.id}});
+    res.json(u);
   });
 
-  app.get("/api/cms/section_description/get/:id", (req, res) => {
-    db.sections_descriptions.findOne({where: {id: req.params.id}}).then(u => res.json(u));
+  app.get("/api/cms/section_description/get/:id", async(req, res) => {
+    const u = await db.sections_descriptions.findOne({where: {id: req.params.id}});
+    res.json(u);
   });
 
-  app.get("/api/cms/topic_subtitle/get/:id", (req, res) => {
-    db.topics_subtitles.findOne({where: {id: req.params.id}}).then(u => res.json(u));
+  app.get("/api/cms/topic_subtitle/get/:id", async(req, res) => {
+    const u = await db.topics_subtitles.findOne({where: {id: req.params.id}});
+    res.json(u);
   });
 
-  app.get("/api/cms/topic_description/get/:id", (req, res) => {
-    db.topics_descriptions.findOne({where: {id: req.params.id}}).then(u => res.json(u));
+  app.get("/api/cms/topic_description/get/:id", async(req, res) => {
+    const u = await db.topics_descriptions.findOne({where: {id: req.params.id}});
+    res.json(u);
   });
 
-  app.get("/api/cms/topic_stat/get/:id", (req, res) => {
-    db.topics_stats.findOne({where: {id: req.params.id}}).then(u => res.json(u));
+  app.get("/api/cms/topic_stat/get/:id", async(req, res) => {
+    const u = await db.topics_stats.findOne({where: {id: req.params.id}});
+    res.json(u);
   });
 
-  app.get("/api/cms/topic_visualization/get/:id", (req, res) => {
-    db.topics_visualizations.findOne({where: {id: req.params.id}}).then(u => res.json(u));
+  app.get("/api/cms/topic_visualization/get/:id", async(req, res) => {
+    const u = await db.topics_visualizations.findOne({where: {id: req.params.id}});
+    res.json(u);
   });
 
-  app.get("/api/cms/selector/get/:id", (req, res) => {
-    db.selectors.findOne({where: {id: req.params.id}}).then(u => res.json(u));
+  app.get("/api/cms/selector/get/:id", async(req, res) => {
+    const u = await db.selectors.findOne({where: {id: req.params.id}});
+    res.json(u);
   });
 
-  app.get("/api/cms/storytopic_subtitle/get/:id", (req, res) => {
-    db.storytopics_subtitles.findOne({where: {id: req.params.id}}).then(u => res.json(u));
+  app.get("/api/cms/storytopic_subtitle/get/:id", async(req, res) => {
+    const u = await db.storytopics_subtitles.findOne({where: {id: req.params.id}});
+    res.json(u);
   });
 
-  app.get("/api/cms/storytopic_description/get/:id", (req, res) => {
-    db.storytopics_descriptions.findOne({where: {id: req.params.id}}).then(u => res.json(u));
+  app.get("/api/cms/storytopic_description/get/:id", async(req, res) => {
+    const u = await db.storytopics_descriptions.findOne({where: {id: req.params.id}});
+    res.json(u);
   });
 
-  app.get("/api/cms/storytopic_stat/get/:id", (req, res) => {
-    db.storytopics_stats.findOne({where: {id: req.params.id}}).then(u => res.json(u));
+  app.get("/api/cms/storytopic_stat/get/:id", async(req, res) => {
+    const u = await db.storytopics_stats.findOne({where: {id: req.params.id}});
+    res.json(u);
   });
 
-  app.get("/api/cms/storytopic_visualization/get/:id", (req, res) => {
-    db.storytopics_visualizations.findOne({where: {id: req.params.id}}).then(u => res.json(u));
+  app.get("/api/cms/storytopic_visualization/get/:id", async(req, res) => {
+    const u = await db.storytopics_visualizations.findOne({where: {id: req.params.id}});
+    res.json(u);
   });
 
   /* END PIECEMEAL CMS API GETS */
 
-  app.post("/api/cms/generator/new", isEnabled, (req, res) => {
-    db.generators.create(req.body).then(u => res.json(u));
+  app.post("/api/cms/generator/new", isEnabled, async(req, res) => {
+    const u = await db.generators.create(req.body);
+    res.json(u);
   });
 
-  app.post("/api/cms/generator/update", isEnabled, (req, res) => {
-    db.generators.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
+  app.post("/api/cms/generator/update", isEnabled, async(req, res) => {
+    const u = await db.generators.update(req.body, {where: {id: req.body.id}});
+    res.json(u);
   });
 
-  app.delete("/api/cms/generator/delete", isEnabled, (req, res) => {
-    db.generators.findOne({where: {id: req.query.id}}).then(row => {
-      db.generators.destroy({where: {id: req.query.id}}).then(() => {
-        db.generators.findAll({where: {profile_id: row.profile_id}, attributes: ["id", "name"]}).then(rows => {
-          res.json(rows);
-        });
-      });
-    });
+  // testme
+  app.delete("/api/cms/generator/delete", isEnabled, async(req, res) => {
+    const row = await db.generators.findOne({where: {id: req.query.id}});
+    const del = await db.generators.destroy({where: {id: req.query.id}});
+    const rows = await db.generators.findAll({where: {profile_id: row.profile_id}, attributes: ["id", "name"]});
+    res.json(rows);
   });
 
-  app.post("/api/cms/materializer/new", isEnabled, (req, res) => {
-    db.materializers.create(req.body).then(u => res.json(u));
+  app.post("/api/cms/materializer/new", isEnabled, async(req, res) => {
+    const u = await db.materializers.create(req.body);
+    res.json(u);
   });
 
-  app.post("/api/cms/materializer/update", isEnabled, (req, res) => {
-    db.materializers.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
+  app.post("/api/cms/materializer/update", isEnabled, async(req, res) => {
+    const u = await db.materializers.update(req.body, {where: {id: req.body.id}});
+    res.json(u);
   });
 
-  app.delete("/api/cms/materializer/delete", isEnabled, (req, res) => {
-    db.materializers.findOne({where: {id: req.query.id}}).then(row => {
-      db.materializers.update({ordering: sequelize.literal("ordering -1")}, {where: {profile_id: row.profile_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
-        db.materializers.destroy({where: {id: req.query.id}}).then(() => {
-          db.materializers.findAll({where: {profile_id: row.profile_id}, attributes: ["id", "ordering", "name"], order: [["ordering", "ASC"]]}).then(rows => {
-            res.json(rows);
-          });
-        });
-      });
-    });
+  // testme
+  app.delete("/api/cms/materializer/delete", isEnabled, async(req, res) => {
+    const row = await db.materializers.findOne({where: {id: req.query.id}});
+    const up = await db.materializers.update({ordering: sequelize.literal("ordering -1")}, {where: {profile_id: row.profile_id, ordering: {[Op.gt]: row.ordering}}});
+    const del = await db.materializers.destroy({where: {id: req.query.id}});
+    const rows = await db.materializers.findAll({where: {profile_id: row.profile_id}, attributes: ["id", "ordering", "name"], order: [["ordering", "ASC"]]});
+    res.json(rows);
   });
 
-  app.post("/api/cms/profile/update", isEnabled, (req, res) => {
-    db.profiles.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
+  app.post("/api/cms/profile/update", isEnabled, async(req, res) => {
+    const u = await db.profiles.update(req.body, {where: {id: req.body.id}});
+    res.json(u);
   });
 
-  app.post("/api/cms/profile/new", isEnabled, (req, res) => {
-    db.profiles.create(req.body).then(u => res.json(u));
+  app.post("/api/cms/profile/new", isEnabled, async(req, res) => {
+    const u = await db.profiles.create(req.body);
+    res.json(u);
   });
 
-  app.delete("/api/cms/profile/delete", isEnabled, (req, res) => {
-    // db.profiles.destroy({where: {id: req.query.id}}).then(u => res.json(u));
-    db.profiles.findOne({where: {id: req.query.id}}).then(row => {
-      db.profiles.update({ordering: sequelize.literal("ordering -1")}, {where: {ordering: {[Op.gt]: row.ordering}}}).then(() => {
-        db.profiles.destroy({where: {id: req.query.id}}).then(() => {
-          db.profiles.findAll(profileReqTreeOnly).then(profiles => {
-            profiles = sortProfileTree(profiles);
-            res.json(profiles);
-          });
-        });
-      });
-    });
+  // testme
+  app.delete("/api/cms/profile/delete", isEnabled, async(req, res) => {
+    const row = await db.profiles.findOne({where: {id: req.query.id}});
+    const up = await db.profiles.update({ordering: sequelize.literal("ordering -1")}, {where: {ordering: {[Op.gt]: row.ordering}}});
+    const del = await db.profiles.destroy({where: {id: req.query.id}});
+    let profiles = await db.profiles.findAll(profileReqTreeOnly);
+    profiles = sortProfileTree(profiles);
+    res.json(profiles);
   });
 
-  app.post("/api/cms/story/update", isEnabled, (req, res) => {
-    db.stories.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
+  app.post("/api/cms/story/update", isEnabled, async(req, res) => {
+    const u = await db.stories.update(req.body, {where: {id: req.body.id}});
+    res.json(u);
   });
 
-  app.post("/api/cms/story/new", isEnabled, (req, res) => {
-    db.stories.create(req.body).then(u => res.json(u));
+  app.post("/api/cms/story/new", isEnabled, async(req, res) => {
+    const u = await db.stories.create(req.body);
+    res.json(u);
   });
 
-  app.delete("/api/cms/story/delete", isEnabled, (req, res) => {
-    db.stories.findOne({where: {id: req.query.id}}).then(row => {
-      db.stories.update({ordering: sequelize.literal("ordering -1")}, {where: {ordering: {[Op.gt]: row.ordering}}}).then(() => {
-        db.stories.destroy({where: {id: req.query.id}}).then(() => {
-          db.stories.findAll(storyReqTreeOnly).then(stories => {
-            stories = sortStoryTree(stories);
-            res.json(stories);
-          });
-        });
-      });
-    });
+  // testme
+  app.delete("/api/cms/story/delete", isEnabled, async(req, res) => {
+    const row = await db.stories.findOne({where: {id: req.query.id}})
+    const up = await db.stories.update({ordering: sequelize.literal("ordering -1")}, {where: {ordering: {[Op.gt]: row.ordering}}});
+    const del = await db.stories.destroy({where: {id: req.query.id}});      
+    let stories = await db.stories.findAll(storyReqTreeOnly);
+    stories = sortStoryTree(stories);
+    res.json(stories);
   });
 
-  app.post("/api/cms/author/update", isEnabled, (req, res) => {
-    db.authors.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
+  app.post("/api/cms/author/update", isEnabled, async(req, res) => {
+    const u = await db.authors.update(req.body, {where: {id: req.body.id}});
+    res.json(u);
   });
 
-  app.post("/api/cms/author/new", isEnabled, (req, res) => {
-    db.authors.create(req.body).then(u => res.json(u));
+  app.post("/api/cms/author/new", isEnabled, async(req, res) => {
+    const u = await db.authors.create(req.body);
+    res.json(u);
   });
 
-  app.delete("/api/cms/author/delete", isEnabled, (req, res) => {
-    db.authors.findOne({where: {id: req.query.id}}).then(row => {
-      db.authors.update({ordering: sequelize.literal("ordering -1")}, {where: {story_id: row.story_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
-        db.authors.destroy({where: {id: req.query.id}}).then(() => {
-          db.authors.findAll({where: {story_id: row.story_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).then(rows => {
-            res.json(rows);
-          });
-        });
-      });
-    });
+  app.delete("/api/cms/author/delete", isEnabled, async(req, res) => {
+    const row = await db.authors.findOne({where: {id: req.query.id}});
+    const up = await db.authors.update({ordering: sequelize.literal("ordering -1")}, {where: {story_id: row.story_id, ordering: {[Op.gt]: row.ordering}}});
+    const del = await db.authors.destroy({where: {id: req.query.id}});
+    const rows = await db.authors.findAll({where: {story_id: row.story_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]});
+    res.json(rows);
   });
 
-  app.post("/api/cms/profile_description/update", isEnabled, (req, res) => {
-    db.profiles_descriptions.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
+  app.post("/api/cms/profile_description/update", isEnabled, async(req, res) => {
+    const u = await db.profiles_descriptions.update(req.body, {where: {id: req.body.id}});
+    res.json(u);
   });
 
-  app.post("/api/cms/profile_description/new", isEnabled, (req, res) => {
-    db.profiles_descriptions.create(req.body).then(u => res.json(u));
+  app.post("/api/cms/profile_description/new", isEnabled, async(req, res) => {
+    const u = await db.profiles_descriptions.create(req.body);
+    res.json(u);
   });
 
-  app.delete("/api/cms/profile_description/delete", isEnabled, (req, res) => {
+  // testme
+  app.delete("/api/cms/profile_description/delete", isEnabled, async(req, res) => {
     db.profiles_descriptions.findOne({where: {id: req.query.id}}).then(row => {
       db.profiles_descriptions.update({ordering: sequelize.literal("ordering -1")}, {where: {profile_id: row.profile_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
         db.profiles_descriptions.destroy({where: {id: req.query.id}}).then(() => {
@@ -411,15 +418,15 @@ module.exports = function(app) {
     });
   });
 
-  app.post("/api/cms/story_description/update", isEnabled, (req, res) => {
+  app.post("/api/cms/story_description/update", isEnabled, async(req, res) => {
     db.stories_descriptions.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
   });
 
-  app.post("/api/cms/story_description/new", isEnabled, (req, res) => {
+  app.post("/api/cms/story_description/new", isEnabled, async(req, res) => {
     db.stories_descriptions.create(req.body).then(u => res.json(u));
   });
 
-  app.delete("/api/cms/story_description/delete", isEnabled, (req, res) => {
+  app.delete("/api/cms/story_description/delete", isEnabled, async(req, res) => {
     db.stories_descriptions.findOne({where: {id: req.query.id}}).then(row => {
       db.stories_descriptions.update({ordering: sequelize.literal("ordering -1")}, {where: {story_id: row.story_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
         db.stories_descriptions.destroy({where: {id: req.query.id}}).then(() => {
@@ -431,15 +438,15 @@ module.exports = function(app) {
     });
   });
 
-  app.post("/api/cms/story_footnote/update", isEnabled, (req, res) => {
+  app.post("/api/cms/story_footnote/update", isEnabled, async(req, res) => {
     db.stories_footnotes.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
   });
 
-  app.post("/api/cms/story_footnote/new", isEnabled, (req, res) => {
+  app.post("/api/cms/story_footnote/new", isEnabled, async(req, res) => {
     db.stories_footnotes.create(req.body).then(u => res.json(u));
   });
 
-  app.delete("/api/cms/story_footnote/delete", isEnabled, (req, res) => {
+  app.delete("/api/cms/story_footnote/delete", isEnabled, async(req, res) => {
     db.stories_footnotes.findOne({where: {id: req.query.id}}).then(row => {
       db.stories_footnotes.update({ordering: sequelize.literal("ordering -1")}, {where: {story_id: row.story_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
         db.stories_footnotes.destroy({where: {id: req.query.id}}).then(() => {
@@ -451,15 +458,15 @@ module.exports = function(app) {
     });
   });
 
-  app.post("/api/cms/section/update", isEnabled, (req, res) => {
+  app.post("/api/cms/section/update", isEnabled, async(req, res) => {
     db.sections.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
   });
 
-  app.post("/api/cms/section/new", isEnabled, (req, res) => {
+  app.post("/api/cms/section/new", isEnabled, async(req, res) => {
     db.sections.create(req.body).then(u => res.json(u));
   });
 
-  app.delete("/api/cms/section/delete", isEnabled, (req, res) => {
+  app.delete("/api/cms/section/delete", isEnabled, async(req, res) => {
     db.sections.findOne({where: {id: req.query.id}}).then(row => {
       db.sections.update({ordering: sequelize.literal("ordering -1")}, {where: {profile_id: row.profile_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
         db.sections.destroy({where: {id: req.query.id}}).then(() => {
@@ -478,15 +485,15 @@ module.exports = function(app) {
     });
   });
 
-  app.post("/api/cms/section_subtitle/update", isEnabled, (req, res) => {
+  app.post("/api/cms/section_subtitle/update", isEnabled, async(req, res) => {
     db.sections_subtitles.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
   });
 
-  app.post("/api/cms/section_subtitle/new", isEnabled, (req, res) => {
+  app.post("/api/cms/section_subtitle/new", isEnabled, async(req, res) => {
     db.sections_subtitles.create(req.body).then(u => res.json(u));
   });
 
-  app.delete("/api/cms/section_subtitle/delete", isEnabled, (req, res) => {
+  app.delete("/api/cms/section_subtitle/delete", isEnabled, async(req, res) => {
     db.sections_subtitles.findOne({where: {id: req.query.id}}).then(row => {
       db.sections_subtitles.update({ordering: sequelize.literal("ordering -1")}, {where: {section_id: row.section_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
         db.sections_subtitles.destroy({where: {id: req.query.id}}).then(() => {
@@ -498,15 +505,15 @@ module.exports = function(app) {
     });
   });
 
-  app.post("/api/cms/section_description/update", isEnabled, (req, res) => {
+  app.post("/api/cms/section_description/update", isEnabled, async(req, res) => {
     db.sections_descriptions.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
   });
 
-  app.post("/api/cms/section_description/new", isEnabled, (req, res) => {
+  app.post("/api/cms/section_description/new", isEnabled, async(req, res) => {
     db.sections_descriptions.create(req.body).then(u => res.json(u));
   });
 
-  app.delete("/api/cms/section_description/delete", isEnabled, (req, res) => {
+  app.delete("/api/cms/section_description/delete", isEnabled, async(req, res) => {
     db.sections_descriptions.findOne({where: {id: req.query.id}}).then(row => {
       db.sections_descriptions.update({ordering: sequelize.literal("ordering -1")}, {where: {section_id: row.section_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
         db.sections_descriptions.destroy({where: {id: req.query.id}}).then(() => {
@@ -518,15 +525,15 @@ module.exports = function(app) {
     });
   });
 
-  app.post("/api/cms/topic/update", isEnabled, (req, res) => {
+  app.post("/api/cms/topic/update", isEnabled, async(req, res) => {
     db.topics.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
   });
 
-  app.post("/api/cms/topic/new", isEnabled, (req, res) => {
+  app.post("/api/cms/topic/new", isEnabled, async(req, res) => {
     db.topics.create(req.body).then(u => res.json(u));
   });
 
-  app.delete("/api/cms/topic/delete", isEnabled, (req, res) => {
+  app.delete("/api/cms/topic/delete", isEnabled, async(req, res) => {
     db.topics.findOne({where: {id: req.query.id}}).then(row => {
       db.topics.update({ordering: sequelize.literal("ordering -1")}, {where: {section_id: row.section_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
         db.topics.destroy({where: {id: req.query.id}}).then(() => {
@@ -538,15 +545,15 @@ module.exports = function(app) {
     });
   });
 
-  app.post("/api/cms/storytopic/update", isEnabled, (req, res) => {
+  app.post("/api/cms/storytopic/update", isEnabled, async(req, res) => {
     db.storytopics.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
   });
 
-  app.post("/api/cms/storytopic/new", isEnabled, (req, res) => {
+  app.post("/api/cms/storytopic/new", isEnabled, async(req, res) => {
     db.storytopics.create(req.body).then(u => res.json(u));
   });
 
-  app.delete("/api/cms/storytopic/delete", isEnabled, (req, res) => {
+  app.delete("/api/cms/storytopic/delete", isEnabled, async(req, res) => {
     db.storytopics.findOne({where: {id: req.query.id}}).then(row => {
       db.storytopics.update({ordering: sequelize.literal("ordering -1")}, {where: {story_id: row.story_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
         db.storytopics.destroy({where: {id: req.query.id}}).then(() => {
@@ -558,15 +565,15 @@ module.exports = function(app) {
     });
   });
 
-  app.post("/api/cms/topic_subtitle/update", isEnabled, (req, res) => {
+  app.post("/api/cms/topic_subtitle/update", isEnabled, async(req, res) => {
     db.topics_subtitles.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
   });
 
-  app.post("/api/cms/topic_subtitle/new", isEnabled, (req, res) => {
+  app.post("/api/cms/topic_subtitle/new", isEnabled, async(req, res) => {
     db.topics_subtitles.create(req.body).then(u => res.json(u));
   });
 
-  app.delete("/api/cms/topic_subtitle/delete", isEnabled, (req, res) => {
+  app.delete("/api/cms/topic_subtitle/delete", isEnabled, async(req, res) => {
     db.topics_subtitles.findOne({where: {id: req.query.id}}).then(row => {
       db.topics_subtitles.update({ordering: sequelize.literal("ordering -1")}, {where: {topic_id: row.topic_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
         db.topics_subtitles.destroy({where: {id: req.query.id}}).then(() => {
@@ -578,15 +585,15 @@ module.exports = function(app) {
     });
   });
 
-  app.post("/api/cms/storytopic_subtitle/update", isEnabled, (req, res) => {
+  app.post("/api/cms/storytopic_subtitle/update", isEnabled, async(req, res) => {
     db.storytopics_subtitles.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
   });
 
-  app.post("/api/cms/storytopic_subtitle/new", isEnabled, (req, res) => {
+  app.post("/api/cms/storytopic_subtitle/new", isEnabled, async(req, res) => {
     db.storytopics_subtitles.create(req.body).then(u => res.json(u));
   });
 
-  app.delete("/api/cms/storytopic_subtitle/delete", isEnabled, (req, res) => {
+  app.delete("/api/cms/storytopic_subtitle/delete", isEnabled, async(req, res) => {
     db.storytopics_subtitles.findOne({where: {id: req.query.id}}).then(row => {
       db.storytopics_subtitles.update({ordering: sequelize.literal("ordering -1")}, {where: {storytopic_id: row.storytopic_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
         db.storytopics_subtitles.destroy({where: {id: req.query.id}}).then(() => {
@@ -598,15 +605,15 @@ module.exports = function(app) {
     });
   });
 
-  app.post("/api/cms/topic_description/update", isEnabled, (req, res) => {
+  app.post("/api/cms/topic_description/update", isEnabled, async(req, res) => {
     db.topics_descriptions.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
   });
 
-  app.post("/api/cms/topic_description/new", isEnabled, (req, res) => {
+  app.post("/api/cms/topic_description/new", isEnabled, async(req, res) => {
     db.topics_descriptions.create(req.body).then(u => res.json(u));
   });
 
-  app.delete("/api/cms/topic_description/delete", isEnabled, (req, res) => {
+  app.delete("/api/cms/topic_description/delete", isEnabled, async(req, res) => {
     db.topics_descriptions.findOne({where: {id: req.query.id}}).then(row => {
       db.topics_descriptions.update({ordering: sequelize.literal("ordering -1")}, {where: {topic_id: row.topic_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
         db.topics_descriptions.destroy({where: {id: req.query.id}}).then(() => {
@@ -618,15 +625,15 @@ module.exports = function(app) {
     });
   });
 
-  app.post("/api/cms/storytopic_description/update", isEnabled, (req, res) => {
+  app.post("/api/cms/storytopic_description/update", isEnabled, async(req, res) => {
     db.storytopics_descriptions.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
   });
 
-  app.post("/api/cms/storytopic_description/new", isEnabled, (req, res) => {
+  app.post("/api/cms/storytopic_description/new", isEnabled, async(req, res) => {
     db.storytopics_descriptions.create(req.body).then(u => res.json(u));
   });
 
-  app.delete("/api/cms/storytopic_description/delete", isEnabled, (req, res) => {
+  app.delete("/api/cms/storytopic_description/delete", isEnabled, async(req, res) => {
     db.storytopics_descriptions.findOne({where: {id: req.query.id}}).then(row => {
       db.storytopics_descriptions.update({ordering: sequelize.literal("ordering -1")}, {where: {storytopic_id: row.storytopic_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
         db.storytopics_descriptions.destroy({where: {id: req.query.id}}).then(() => {
@@ -638,15 +645,15 @@ module.exports = function(app) {
     });
   });
 
-  app.post("/api/cms/selector/update", isEnabled, (req, res) => {
+  app.post("/api/cms/selector/update", isEnabled, async(req, res) => {
     db.selectors.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
   });
 
-  app.post("/api/cms/selector/new", isEnabled, (req, res) => {
+  app.post("/api/cms/selector/new", isEnabled, async(req, res) => {
     db.selectors.create(req.body).then(u => res.json(u));
   });
 
-  app.delete("/api/cms/selector/delete", isEnabled, (req, res) => {
+  app.delete("/api/cms/selector/delete", isEnabled, async(req, res) => {
     db.selectors.findOne({where: {id: req.query.id}}).then(row => {
       db.selectors.update({ordering: sequelize.literal("ordering -1")}, {where: {topic_id: row.topic_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
         db.selectors.destroy({where: {id: req.query.id}}).then(() => {
@@ -658,15 +665,15 @@ module.exports = function(app) {
     });
   });
 
-  app.post("/api/cms/profile_stat/update", isEnabled, (req, res) => {
+  app.post("/api/cms/profile_stat/update", isEnabled, async(req, res) => {
     db.profiles_stats.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
   });
 
-  app.post("/api/cms/profile_stat/new", isEnabled, (req, res) => {
+  app.post("/api/cms/profile_stat/new", isEnabled, async(req, res) => {
     db.profiles_stats.create(req.body).then(u => res.json(u));
   });
 
-  app.delete("/api/cms/profile_stat/delete", isEnabled, (req, res) => {
+  app.delete("/api/cms/profile_stat/delete", isEnabled, async(req, res) => {
     db.profiles_stats.findOne({where: {id: req.query.id}}).then(row => {
       db.profiles_stats.update({ordering: sequelize.literal("ordering -1")}, {where: {profile_id: row.profile_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
         db.profiles_stats.destroy({where: {id: req.query.id}}).then(() => {
@@ -678,15 +685,15 @@ module.exports = function(app) {
     });
   });
 
-  app.post("/api/cms/topic_stat/update", isEnabled, (req, res) => {
+  app.post("/api/cms/topic_stat/update", isEnabled, async(req, res) => {
     db.topics_stats.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
   });
 
-  app.post("/api/cms/topic_stat/new", isEnabled, (req, res) => {
+  app.post("/api/cms/topic_stat/new", isEnabled, async(req, res) => {
     db.topics_stats.create(req.body).then(u => res.json(u));
   });
 
-  app.delete("/api/cms/topic_stat/delete", isEnabled, (req, res) => {
+  app.delete("/api/cms/topic_stat/delete", isEnabled, async(req, res) => {
     db.topics_stats.findOne({where: {id: req.query.id}}).then(row => {
       db.topics_stats.update({ordering: sequelize.literal("ordering -1")}, {where: {topic_id: row.topic_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
         db.topics_stats.destroy({where: {id: req.query.id}}).then(() => {
@@ -698,15 +705,15 @@ module.exports = function(app) {
     });
   });
 
-  app.post("/api/cms/storytopic_stat/update", isEnabled, (req, res) => {
+  app.post("/api/cms/storytopic_stat/update", isEnabled, async(req, res) => {
     db.storytopics_stats.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
   });
 
-  app.post("/api/cms/storytopic_stat/new", isEnabled, (req, res) => {
+  app.post("/api/cms/storytopic_stat/new", isEnabled, async(req, res) => {
     db.storytopics_stats.create(req.body).then(u => res.json(u));
   });
 
-  app.delete("/api/cms/storytopic_stat/delete", isEnabled, (req, res) => {
+  app.delete("/api/cms/storytopic_stat/delete", isEnabled, async(req, res) => {
     db.storytopics_stats.findOne({where: {id: req.query.id}}).then(row => {
       db.storytopics_stats.update({ordering: sequelize.literal("ordering -1")}, {where: {storytopic_id: row.storytopic_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
         db.storytopics_stats.destroy({where: {id: req.query.id}}).then(() => {
@@ -718,15 +725,15 @@ module.exports = function(app) {
     });
   });
 
-  app.post("/api/cms/profile_visualization/update", isEnabled, (req, res) => {
+  app.post("/api/cms/profile_visualization/update", isEnabled, async(req, res) => {
     db.profiles_visualizations.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
   });
 
-  app.post("/api/cms/profile_visualization/new", isEnabled, (req, res) => {
+  app.post("/api/cms/profile_visualization/new", isEnabled, async(req, res) => {
     db.profiles_visualizations.create(req.body).then(u => res.json(u));
   });
 
-  app.delete("/api/cms/profile_visualization/delete", isEnabled, (req, res) => {
+  app.delete("/api/cms/profile_visualization/delete", isEnabled, async(req, res) => {
     db.profiles_visualizations.findOne({where: {id: req.query.id}}).then(row => {
       db.profiles_visualizations.update({ordering: sequelize.literal("ordering -1")}, {where: {profile_id: row.profile_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
         db.profiles_visualizations.destroy({where: {id: req.query.id}}).then(() => {
@@ -738,15 +745,15 @@ module.exports = function(app) {
     });
   });
 
-  app.post("/api/cms/topic_visualization/update", isEnabled, (req, res) => {
+  app.post("/api/cms/topic_visualization/update", isEnabled, async(req, res) => {
     db.topics_visualizations.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
   });
 
-  app.post("/api/cms/topic_visualization/new", isEnabled, (req, res) => {
+  app.post("/api/cms/topic_visualization/new", isEnabled, async(req, res) => {
     db.topics_visualizations.create(req.body).then(u => res.json(u));
   });
 
-  app.delete("/api/cms/topic_visualization/delete", isEnabled, (req, res) => {
+  app.delete("/api/cms/topic_visualization/delete", isEnabled, async(req, res) => {
     db.topics_visualizations.findOne({where: {id: req.query.id}}).then(row => {
       db.topics_visualizations.update({ordering: sequelize.literal("ordering -1")}, {where: {topic_id: row.topic_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
         db.topics_visualizations.destroy({where: {id: req.query.id}}).then(() => {
@@ -758,15 +765,15 @@ module.exports = function(app) {
     });
   });
 
-  app.post("/api/cms/storytopic_visualization/update", isEnabled, (req, res) => {
+  app.post("/api/cms/storytopic_visualization/update", isEnabled, async(req, res) => {
     db.storytopics_visualizations.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
   });
 
-  app.post("/api/cms/storytopic_visualization/new", isEnabled, (req, res) => {
+  app.post("/api/cms/storytopic_visualization/new", isEnabled, async(req, res) => {
     db.storytopics_visualizations.create(req.body).then(u => res.json(u));
   });
 
-  app.delete("/api/cms/storytopic_visualization/delete", isEnabled, (req, res) => {
+  app.delete("/api/cms/storytopic_visualization/delete", isEnabled, async(req, res) => {
     db.storytopics_visualizations.findOne({where: {id: req.query.id}}).then(row => {
       db.storytopics_visualizations.update({ordering: sequelize.literal("ordering -1")}, {where: {storytopic_id: row.storytopic_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
         db.storytopics_visualizations.destroy({where: {id: req.query.id}}).then(() => {

--- a/api/cmsRoute.js
+++ b/api/cmsRoute.js
@@ -312,10 +312,9 @@ module.exports = function(app) {
     res.json(u);
   });
 
-  // testme
   app.delete("/api/cms/generator/delete", isEnabled, async(req, res) => {
     const row = await db.generators.findOne({where: {id: req.query.id}}).catch(catcher);
-    const del = await db.generators.destroy({where: {id: req.query.id}}).catch(catcher);
+    await db.generators.destroy({where: {id: req.query.id}}).catch(catcher);
     const rows = await db.generators.findAll({where: {profile_id: row.profile_id}, attributes: ["id", "name"]}).catch(catcher);
     res.json(rows);
   });
@@ -330,11 +329,10 @@ module.exports = function(app) {
     res.json(u);
   });
 
-  // testme
   app.delete("/api/cms/materializer/delete", isEnabled, async(req, res) => {
     const row = await db.materializers.findOne({where: {id: req.query.id}}).catch(catcher);
-    const up = await db.materializers.update({ordering: sequelize.literal("ordering -1")}, {where: {profile_id: row.profile_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
-    const del = await db.materializers.destroy({where: {id: req.query.id}}).catch(catcher);
+    await db.materializers.update({ordering: sequelize.literal("ordering -1")}, {where: {profile_id: row.profile_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    await db.materializers.destroy({where: {id: req.query.id}}).catch(catcher);
     const rows = await db.materializers.findAll({where: {profile_id: row.profile_id}, attributes: ["id", "ordering", "name"], order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
@@ -349,11 +347,10 @@ module.exports = function(app) {
     res.json(u);
   });
 
-  // testme
   app.delete("/api/cms/profile/delete", isEnabled, async(req, res) => {
     const row = await db.profiles.findOne({where: {id: req.query.id}}).catch(catcher);
-    const up = await db.profiles.update({ordering: sequelize.literal("ordering -1")}, {where: {ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
-    const del = await db.profiles.destroy({where: {id: req.query.id}}).catch(catcher);
+    await db.profiles.update({ordering: sequelize.literal("ordering -1")}, {where: {ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    await db.profiles.destroy({where: {id: req.query.id}}).catch(catcher);
     let profiles = await db.profiles.findAll(profileReqTreeOnly).catch(catcher);
     profiles = sortProfileTree(profiles);
     res.json(profiles);
@@ -369,11 +366,10 @@ module.exports = function(app) {
     res.json(u);
   });
 
-  // testme
   app.delete("/api/cms/story/delete", isEnabled, async(req, res) => {
     const row = await db.stories.findOne({where: {id: req.query.id}}).catch(catcher);
-    const up = await db.stories.update({ordering: sequelize.literal("ordering -1")}, {where: {ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
-    const del = await db.stories.destroy({where: {id: req.query.id}}).catch(catcher);      
+    await db.stories.update({ordering: sequelize.literal("ordering -1")}, {where: {ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    await db.stories.destroy({where: {id: req.query.id}}).catch(catcher);      
     let stories = await db.stories.findAll(storyReqTreeOnly).catch(catcher);
     stories = sortStoryTree(stories);
     res.json(stories);
@@ -391,8 +387,8 @@ module.exports = function(app) {
 
   app.delete("/api/cms/author/delete", isEnabled, async(req, res) => {
     const row = await db.authors.findOne({where: {id: req.query.id}}).catch(catcher);
-    const up = await db.authors.update({ordering: sequelize.literal("ordering -1")}, {where: {story_id: row.story_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
-    const del = await db.authors.destroy({where: {id: req.query.id}}).catch(catcher);
+    await db.authors.update({ordering: sequelize.literal("ordering -1")}, {where: {story_id: row.story_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    await db.authors.destroy({where: {id: req.query.id}}).catch(catcher);
     const rows = await db.authors.findAll({where: {story_id: row.story_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
@@ -407,11 +403,10 @@ module.exports = function(app) {
     res.json(u);
   });
 
-  // testme
   app.delete("/api/cms/profile_description/delete", isEnabled, async(req, res) => {
     const row = await db.profiles_descriptions.findOne({where: {id: req.query.id}}).catch(catcher);
-    const up = await db.profiles_descriptions.update({ordering: sequelize.literal("ordering -1")}, {where: {profile_id: row.profile_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
-    const del = await db.profiles_descriptions.destroy({where: {id: req.query.id}}).catch(catcher);
+    await db.profiles_descriptions.update({ordering: sequelize.literal("ordering -1")}, {where: {profile_id: row.profile_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    await db.profiles_descriptions.destroy({where: {id: req.query.id}}).catch(catcher);
     const rows = await db.profiles_descriptions.findAll({where: {profile_id: row.profile_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
@@ -428,8 +423,8 @@ module.exports = function(app) {
 
   app.delete("/api/cms/story_description/delete", isEnabled, async(req, res) => {
     const row = await db.stories_descriptions.findOne({where: {id: req.query.id}}).catch(catcher);
-    const up = await db.stories_descriptions.update({ordering: sequelize.literal("ordering -1")}, {where: {story_id: row.story_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
-    const del = await db.stories_descriptions.destroy({where: {id: req.query.id}}).catch(catcher);
+    await db.stories_descriptions.update({ordering: sequelize.literal("ordering -1")}, {where: {story_id: row.story_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    await db.stories_descriptions.destroy({where: {id: req.query.id}}).catch(catcher);
     const rows = await db.stories_descriptions.findAll({where: {story_id: row.story_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
@@ -446,8 +441,8 @@ module.exports = function(app) {
 
   app.delete("/api/cms/story_footnote/delete", isEnabled, async(req, res) => {
     const row = await db.stories_footnotes.findOne({where: {id: req.query.id}}).catch(catcher);
-    const up = await db.stories_footnotes.update({ordering: sequelize.literal("ordering -1")}, {where: {story_id: row.story_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
-    const del = await db.stories_footnotes.destroy({where: {id: req.query.id}}).catch(catcher);
+    await db.stories_footnotes.update({ordering: sequelize.literal("ordering -1")}, {where: {story_id: row.story_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    await db.stories_footnotes.destroy({where: {id: req.query.id}}).catch(catcher);
     const rows = await db.stories_footnotes.findAll({where: {story_id: row.story_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
@@ -464,8 +459,8 @@ module.exports = function(app) {
 
   app.delete("/api/cms/section/delete", isEnabled, async(req, res) => {
     const row = await db.sections.findOne({where: {id: req.query.id}}).catch(catcher);
-    const up = await db.sections.update({ordering: sequelize.literal("ordering -1")}, {where: {profile_id: row.profile_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
-    const del = await db.sections.destroy({where: {id: req.query.id}}).catch(catcher);
+    await db.sections.update({ordering: sequelize.literal("ordering -1")}, {where: {profile_id: row.profile_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    await db.sections.destroy({where: {id: req.query.id}}).catch(catcher);
     const rows = await db.sections.findAll({
       where: {profile_id: row.profile_id},
       attributes: ["id", "title", "slug", "ordering", "profile_id"],
@@ -489,8 +484,8 @@ module.exports = function(app) {
 
   app.delete("/api/cms/section_subtitle/delete", isEnabled, async(req, res) => {
     const row = await db.sections_subtitles.findOne({where: {id: req.query.id}}).catch(catcher);
-    const up = await db.sections_subtitles.update({ordering: sequelize.literal("ordering -1")}, {where: {section_id: row.section_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
-    const del = await db.sections_subtitles.destroy({where: {id: req.query.id}}).catch(catcher);
+    await db.sections_subtitles.update({ordering: sequelize.literal("ordering -1")}, {where: {section_id: row.section_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    await db.sections_subtitles.destroy({where: {id: req.query.id}}).catch(catcher);
     const rows = await db.sections_subtitles.findAll({where: {section_id: row.section_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
@@ -507,8 +502,8 @@ module.exports = function(app) {
 
   app.delete("/api/cms/section_description/delete", isEnabled, async(req, res) => {
     const row = await db.sections_descriptions.findOne({where: {id: req.query.id}}).catch(catcher);
-    const up = await db.sections_descriptions.update({ordering: sequelize.literal("ordering -1")}, {where: {section_id: row.section_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
-    const del = await db.sections_descriptions.destroy({where: {id: req.query.id}}).catch(catcher);
+    await db.sections_descriptions.update({ordering: sequelize.literal("ordering -1")}, {where: {section_id: row.section_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    await db.sections_descriptions.destroy({where: {id: req.query.id}}).catch(catcher);
     const rows = await db.sections_descriptions.findAll({where: {section_id: row.section_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
@@ -525,8 +520,8 @@ module.exports = function(app) {
 
   app.delete("/api/cms/topic/delete", isEnabled, async(req, res) => {
     const row = await db.topics.findOne({where: {id: req.query.id}}).catch(catcher);
-    const up = await db.topics.update({ordering: sequelize.literal("ordering -1")}, {where: {section_id: row.section_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
-    const del = await db.topics.destroy({where: {id: req.query.id}}).catch(catcher);
+    await db.topics.update({ordering: sequelize.literal("ordering -1")}, {where: {section_id: row.section_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    await db.topics.destroy({where: {id: req.query.id}}).catch(catcher);
     const rows = await db.topics.findAll({where: {section_id: row.section_id}, attributes: ["id", "title", "slug", "ordering", "section_id", "type"], order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
@@ -543,8 +538,8 @@ module.exports = function(app) {
 
   app.delete("/api/cms/storytopic/delete", isEnabled, async(req, res) => {
     const row = await db.storytopics.findOne({where: {id: req.query.id}}).catch(catcher);
-    const up = await db.storytopics.update({ordering: sequelize.literal("ordering -1")}, {where: {story_id: row.story_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
-    const del = await db.storytopics.destroy({where: {id: req.query.id}}).catch(catcher);
+    await db.storytopics.update({ordering: sequelize.literal("ordering -1")}, {where: {story_id: row.story_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    await db.storytopics.destroy({where: {id: req.query.id}}).catch(catcher);
     const rows = await db.storytopics.findAll({where: {story_id: row.story_id}, attributes: ["id", "title", "slug", "ordering", "story_id", "type"], order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
@@ -561,8 +556,8 @@ module.exports = function(app) {
 
   app.delete("/api/cms/topic_subtitle/delete", isEnabled, async(req, res) => {
     const row = await db.topics_subtitles.findOne({where: {id: req.query.id}}).catch(catcher);
-    const up = await db.topics_subtitles.update({ordering: sequelize.literal("ordering -1")}, {where: {topic_id: row.topic_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
-    const del = await db.topics_subtitles.destroy({where: {id: req.query.id}}).catch(catcher);
+    await db.topics_subtitles.update({ordering: sequelize.literal("ordering -1")}, {where: {topic_id: row.topic_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    await db.topics_subtitles.destroy({where: {id: req.query.id}}).catch(catcher);
     const rows = await db.topics_subtitles.findAll({where: {topic_id: row.topic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
@@ -579,8 +574,8 @@ module.exports = function(app) {
 
   app.delete("/api/cms/storytopic_subtitle/delete", isEnabled, async(req, res) => {
     const row = await db.storytopics_subtitles.findOne({where: {id: req.query.id}}).catch(catcher);
-    const up = await db.storytopics_subtitles.update({ordering: sequelize.literal("ordering -1")}, {where: {storytopic_id: row.storytopic_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
-    const del = await db.storytopics_subtitles.destroy({where: {id: req.query.id}}).catch(catcher);
+    await db.storytopics_subtitles.update({ordering: sequelize.literal("ordering -1")}, {where: {storytopic_id: row.storytopic_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    await db.storytopics_subtitles.destroy({where: {id: req.query.id}}).catch(catcher);
     const rows = await db.storytopics_subtitles.findAll({where: {storytopic_id: row.storytopic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
@@ -597,8 +592,8 @@ module.exports = function(app) {
 
   app.delete("/api/cms/topic_description/delete", isEnabled, async(req, res) => {
     const row = await db.topics_descriptions.findOne({where: {id: req.query.id}}).catch(catcher);
-    const up = await db.topics_descriptions.update({ordering: sequelize.literal("ordering -1")}, {where: {topic_id: row.topic_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
-    const del = await db.topics_descriptions.destroy({where: {id: req.query.id}}).catch(catcher);
+    await db.topics_descriptions.update({ordering: sequelize.literal("ordering -1")}, {where: {topic_id: row.topic_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    await db.topics_descriptions.destroy({where: {id: req.query.id}}).catch(catcher);
     const rows = await db.topics_descriptions.findAll({where: {topic_id: row.topic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
@@ -615,8 +610,8 @@ module.exports = function(app) {
 
   app.delete("/api/cms/storytopic_description/delete", isEnabled, async(req, res) => {
     const row = await db.storytopics_descriptions.findOne({where: {id: req.query.id}}).catch(catcher);
-    const up = await db.storytopics_descriptions.update({ordering: sequelize.literal("ordering -1")}, {where: {storytopic_id: row.storytopic_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
-    const del = await db.storytopics_descriptions.destroy({where: {id: req.query.id}}).catch(catcher);
+    await db.storytopics_descriptions.update({ordering: sequelize.literal("ordering -1")}, {where: {storytopic_id: row.storytopic_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    await db.storytopics_descriptions.destroy({where: {id: req.query.id}}).catch(catcher);
     const rows = await db.storytopics_descriptions.findAll({where: {storytopic_id: row.storytopic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
@@ -633,8 +628,8 @@ module.exports = function(app) {
 
   app.delete("/api/cms/selector/delete", isEnabled, async(req, res) => {
     const row = await db.selectors.findOne({where: {id: req.query.id}}).catch(catcher);
-    const up = await db.selectors.update({ordering: sequelize.literal("ordering -1")}, {where: {topic_id: row.topic_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
-    const del = await db.selectors.destroy({where: {id: req.query.id}}).catch(catcher);
+    await db.selectors.update({ordering: sequelize.literal("ordering -1")}, {where: {topic_id: row.topic_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    await db.selectors.destroy({where: {id: req.query.id}}).catch(catcher);
     const rows = await db.selectors.findAll({where: {topic_id: row.topic_id}, order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
@@ -651,8 +646,8 @@ module.exports = function(app) {
 
   app.delete("/api/cms/profile_stat/delete", isEnabled, async(req, res) => {
     const row = await db.profiles_stats.findOne({where: {id: req.query.id}}).catch(catcher);
-    const up = await db.profiles_stats.update({ordering: sequelize.literal("ordering -1")}, {where: {profile_id: row.profile_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
-    const del = await db.profiles_stats.destroy({where: {id: req.query.id}}).catch(catcher);
+    await db.profiles_stats.update({ordering: sequelize.literal("ordering -1")}, {where: {profile_id: row.profile_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    await db.profiles_stats.destroy({where: {id: req.query.id}}).catch(catcher);
     const rows = await db.profiles_stats.findAll({where: {profile_id: row.profile_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
@@ -669,8 +664,8 @@ module.exports = function(app) {
 
   app.delete("/api/cms/topic_stat/delete", isEnabled, async(req, res) => {
     const row = await db.topics_stats.findOne({where: {id: req.query.id}}).catch(catcher);
-    const up = await db.topics_stats.update({ordering: sequelize.literal("ordering -1")}, {where: {topic_id: row.topic_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
-    const del = await db.topics_stats.destroy({where: {id: req.query.id}}).catch(catcher);
+    await db.topics_stats.update({ordering: sequelize.literal("ordering -1")}, {where: {topic_id: row.topic_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    await db.topics_stats.destroy({where: {id: req.query.id}}).catch(catcher);
     const rows = await db.topics_stats.findAll({where: {topic_id: row.topic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
@@ -687,8 +682,8 @@ module.exports = function(app) {
 
   app.delete("/api/cms/storytopic_stat/delete", isEnabled, async(req, res) => {
     const row = await db.storytopics_stats.findOne({where: {id: req.query.id}}).catch(catcher);
-    const up = await db.storytopics_stats.update({ordering: sequelize.literal("ordering -1")}, {where: {storytopic_id: row.storytopic_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
-    const del = await db.storytopics_stats.destroy({where: {id: req.query.id}}).catch(catcher);
+    await db.storytopics_stats.update({ordering: sequelize.literal("ordering -1")}, {where: {storytopic_id: row.storytopic_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    await db.storytopics_stats.destroy({where: {id: req.query.id}}).catch(catcher);
     const rows = await db.storytopics_stats.findAll({where: {storytopic_id: row.storytopic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
@@ -705,8 +700,8 @@ module.exports = function(app) {
 
   app.delete("/api/cms/profile_visualization/delete", isEnabled, async(req, res) => {
     const row = await db.profiles_visualizations.findOne({where: {id: req.query.id}}).catch(catcher);
-    const up = await db.profiles_visualizations.update({ordering: sequelize.literal("ordering -1")}, {where: {profile_id: row.profile_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
-    const del = await db.profiles_visualizations.destroy({where: {id: req.query.id}}).catch(catcher);
+    await db.profiles_visualizations.update({ordering: sequelize.literal("ordering -1")}, {where: {profile_id: row.profile_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    await db.profiles_visualizations.destroy({where: {id: req.query.id}}).catch(catcher);
     const rows = await db.profiles_visualizations.findAll({where: {profile_id: row.profile_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
@@ -723,8 +718,8 @@ module.exports = function(app) {
 
   app.delete("/api/cms/topic_visualization/delete", isEnabled, async(req, res) => {
     const row = await db.topics_visualizations.findOne({where: {id: req.query.id}}).catch(catcher);
-    const up = await db.topics_visualizations.update({ordering: sequelize.literal("ordering -1")}, {where: {topic_id: row.topic_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
-    const del = await db.topics_visualizations.destroy({where: {id: req.query.id}}).catch(catcher);
+    await db.topics_visualizations.update({ordering: sequelize.literal("ordering -1")}, {where: {topic_id: row.topic_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    await db.topics_visualizations.destroy({where: {id: req.query.id}}).catch(catcher);
     const rows = await db.topics_visualizations.findAll({where: {topic_id: row.topic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
@@ -741,8 +736,8 @@ module.exports = function(app) {
 
   app.delete("/api/cms/storytopic_visualization/delete", isEnabled, async(req, res) => {
     const row = await db.storytopics_visualizations.findOne({where: {id: req.query.id}}).catch(catcher);
-    const up = await db.storytopics_visualizations.update({ordering: sequelize.literal("ordering -1")}, {where: {storytopic_id: row.storytopic_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
-    const del = await db.storytopics_visualizations.destroy({where: {id: req.query.id}}).catch(catcher);
+    await db.storytopics_visualizations.update({ordering: sequelize.literal("ordering -1")}, {where: {storytopic_id: row.storytopic_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    await db.storytopics_visualizations.destroy({where: {id: req.query.id}}).catch(catcher);
     const rows = await db.storytopics_visualizations.findAll({where: {storytopic_id: row.storytopic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });

--- a/api/cmsRoute.js
+++ b/api/cmsRoute.js
@@ -407,382 +407,342 @@ module.exports = function(app) {
 
   // testme
   app.delete("/api/cms/profile_description/delete", isEnabled, async(req, res) => {
-    db.profiles_descriptions.findOne({where: {id: req.query.id}}).then(row => {
-      db.profiles_descriptions.update({ordering: sequelize.literal("ordering -1")}, {where: {profile_id: row.profile_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
-        db.profiles_descriptions.destroy({where: {id: req.query.id}}).then(() => {
-          db.profiles_descriptions.findAll({where: {profile_id: row.profile_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).then(rows => {
-            res.json(rows);
-          });
-        });
-      });
-    });
+    const row = await db.profiles_descriptions.findOne({where: {id: req.query.id}});
+    const up = await db.profiles_descriptions.update({ordering: sequelize.literal("ordering -1")}, {where: {profile_id: row.profile_id, ordering: {[Op.gt]: row.ordering}}});
+    const del = await db.profiles_descriptions.destroy({where: {id: req.query.id}});
+    const rows = await db.profiles_descriptions.findAll({where: {profile_id: row.profile_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]});
+    res.json(rows);
   });
 
   app.post("/api/cms/story_description/update", isEnabled, async(req, res) => {
-    db.stories_descriptions.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
+    const u = await db.stories_descriptions.update(req.body, {where: {id: req.body.id}});
+    res.json(u);
   });
 
   app.post("/api/cms/story_description/new", isEnabled, async(req, res) => {
-    db.stories_descriptions.create(req.body).then(u => res.json(u));
+    const u = await db.stories_descriptions.create(req.body);
+    res.json(u);
   });
 
   app.delete("/api/cms/story_description/delete", isEnabled, async(req, res) => {
-    db.stories_descriptions.findOne({where: {id: req.query.id}}).then(row => {
-      db.stories_descriptions.update({ordering: sequelize.literal("ordering -1")}, {where: {story_id: row.story_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
-        db.stories_descriptions.destroy({where: {id: req.query.id}}).then(() => {
-          db.stories_descriptions.findAll({where: {story_id: row.story_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).then(rows => {
-            res.json(rows);
-          });
-        });
-      });
-    });
+    const row = await db.stories_descriptions.findOne({where: {id: req.query.id}});
+    const up = await db.stories_descriptions.update({ordering: sequelize.literal("ordering -1")}, {where: {story_id: row.story_id, ordering: {[Op.gt]: row.ordering}}});
+    const del = await db.stories_descriptions.destroy({where: {id: req.query.id}});
+    const rows = await db.stories_descriptions.findAll({where: {story_id: row.story_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]});
+    res.json(rows);
   });
 
   app.post("/api/cms/story_footnote/update", isEnabled, async(req, res) => {
-    db.stories_footnotes.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
+    const u = await db.stories_footnotes.update(req.body, {where: {id: req.body.id}});
+    res.json(u);
   });
 
   app.post("/api/cms/story_footnote/new", isEnabled, async(req, res) => {
-    db.stories_footnotes.create(req.body).then(u => res.json(u));
+    const u = await db.stories_footnotes.create(req.body);
+    res.json(u);
   });
 
   app.delete("/api/cms/story_footnote/delete", isEnabled, async(req, res) => {
-    db.stories_footnotes.findOne({where: {id: req.query.id}}).then(row => {
-      db.stories_footnotes.update({ordering: sequelize.literal("ordering -1")}, {where: {story_id: row.story_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
-        db.stories_footnotes.destroy({where: {id: req.query.id}}).then(() => {
-          db.stories_footnotes.findAll({where: {story_id: row.story_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).then(rows => {
-            res.json(rows);
-          });
-        });
-      });
-    });
+    const row = await db.stories_footnotes.findOne({where: {id: req.query.id}});
+    const up = await db.stories_footnotes.update({ordering: sequelize.literal("ordering -1")}, {where: {story_id: row.story_id, ordering: {[Op.gt]: row.ordering}}});
+    const del = await db.stories_footnotes.destroy({where: {id: req.query.id}});
+    const rows = await db.stories_footnotes.findAll({where: {story_id: row.story_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]});
+    res.json(rows);
   });
 
   app.post("/api/cms/section/update", isEnabled, async(req, res) => {
-    db.sections.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
+    const u = await db.sections.update(req.body, {where: {id: req.body.id}});
+    res.json(u);
   });
 
   app.post("/api/cms/section/new", isEnabled, async(req, res) => {
-    db.sections.create(req.body).then(u => res.json(u));
+    const u = await db.sections.create(req.body);
+    res.json(u);
   });
 
   app.delete("/api/cms/section/delete", isEnabled, async(req, res) => {
-    db.sections.findOne({where: {id: req.query.id}}).then(row => {
-      db.sections.update({ordering: sequelize.literal("ordering -1")}, {where: {profile_id: row.profile_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
-        db.sections.destroy({where: {id: req.query.id}}).then(() => {
-          db.sections.findAll({
-            where: {profile_id: row.profile_id},
-            attributes: ["id", "title", "slug", "ordering", "profile_id"],
-            order: [["ordering", "ASC"]],
-            include: [
-              {association: "topics", attributes: ["id", "title", "slug", "ordering", "section_id"]}
-            ]
-          }).then(rows => {
-            res.json(rows);
-          });
-        });
-      });
+    const row = await db.sections.findOne({where: {id: req.query.id}});
+    const up = await db.sections.update({ordering: sequelize.literal("ordering -1")}, {where: {profile_id: row.profile_id, ordering: {[Op.gt]: row.ordering}}});
+    const del = await db.sections.destroy({where: {id: req.query.id}});
+    const rows = await db.sections.findAll({
+      where: {profile_id: row.profile_id},
+      attributes: ["id", "title", "slug", "ordering", "profile_id"],
+      order: [["ordering", "ASC"]],
+      include: [
+        {association: "topics", attributes: ["id", "title", "slug", "ordering", "section_id"]}
+      ]
     });
+    res.json(rows);
   });
 
   app.post("/api/cms/section_subtitle/update", isEnabled, async(req, res) => {
-    db.sections_subtitles.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
+    const u = await db.sections_subtitles.update(req.body, {where: {id: req.body.id}});
+    res.json(u);
   });
 
   app.post("/api/cms/section_subtitle/new", isEnabled, async(req, res) => {
-    db.sections_subtitles.create(req.body).then(u => res.json(u));
+    const u = await db.sections_subtitles.create(req.body);
+    res.json(u);
   });
 
   app.delete("/api/cms/section_subtitle/delete", isEnabled, async(req, res) => {
-    db.sections_subtitles.findOne({where: {id: req.query.id}}).then(row => {
-      db.sections_subtitles.update({ordering: sequelize.literal("ordering -1")}, {where: {section_id: row.section_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
-        db.sections_subtitles.destroy({where: {id: req.query.id}}).then(() => {
-          db.sections_subtitles.findAll({where: {section_id: row.section_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).then(rows => {
-            res.json(rows);
-          });
-        });
-      });
-    });
+    const row = await db.sections_subtitles.findOne({where: {id: req.query.id}});
+    const up = await db.sections_subtitles.update({ordering: sequelize.literal("ordering -1")}, {where: {section_id: row.section_id, ordering: {[Op.gt]: row.ordering}}});
+    const del = await db.sections_subtitles.destroy({where: {id: req.query.id}});
+    const rows = await db.sections_subtitles.findAll({where: {section_id: row.section_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]});
+    res.json(rows);
   });
 
   app.post("/api/cms/section_description/update", isEnabled, async(req, res) => {
-    db.sections_descriptions.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
+    const u = await db.sections_descriptions.update(req.body, {where: {id: req.body.id}});
+    res.json(u);
   });
 
   app.post("/api/cms/section_description/new", isEnabled, async(req, res) => {
-    db.sections_descriptions.create(req.body).then(u => res.json(u));
+    const u = await db.sections_descriptions.create(req.body);
+    res.json(u);
   });
 
   app.delete("/api/cms/section_description/delete", isEnabled, async(req, res) => {
-    db.sections_descriptions.findOne({where: {id: req.query.id}}).then(row => {
-      db.sections_descriptions.update({ordering: sequelize.literal("ordering -1")}, {where: {section_id: row.section_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
-        db.sections_descriptions.destroy({where: {id: req.query.id}}).then(() => {
-          db.sections_descriptions.findAll({where: {section_id: row.section_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).then(rows => {
-            res.json(rows);
-          });
-        });
-      });
-    });
+    const row = await db.sections_descriptions.findOne({where: {id: req.query.id}});
+    const up = await db.sections_descriptions.update({ordering: sequelize.literal("ordering -1")}, {where: {section_id: row.section_id, ordering: {[Op.gt]: row.ordering}}});
+    const del = await db.sections_descriptions.destroy({where: {id: req.query.id}});
+    const rows = await db.sections_descriptions.findAll({where: {section_id: row.section_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]});
+    res.json(rows);
   });
 
   app.post("/api/cms/topic/update", isEnabled, async(req, res) => {
-    db.topics.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
+    const u = await db.topics.update(req.body, {where: {id: req.body.id}});
+    res.json(u);
   });
 
   app.post("/api/cms/topic/new", isEnabled, async(req, res) => {
-    db.topics.create(req.body).then(u => res.json(u));
+    const u = await db.topics.create(req.body);
+    res.json(u);
   });
 
   app.delete("/api/cms/topic/delete", isEnabled, async(req, res) => {
-    db.topics.findOne({where: {id: req.query.id}}).then(row => {
-      db.topics.update({ordering: sequelize.literal("ordering -1")}, {where: {section_id: row.section_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
-        db.topics.destroy({where: {id: req.query.id}}).then(() => {
-          db.topics.findAll({where: {section_id: row.section_id}, attributes: ["id", "title", "slug", "ordering", "section_id", "type"], order: [["ordering", "ASC"]]}).then(rows => {
-            res.json(rows);
-          });
-        });
-      });
-    });
+    const row = await db.topics.findOne({where: {id: req.query.id}});
+    const up = await db.topics.update({ordering: sequelize.literal("ordering -1")}, {where: {section_id: row.section_id, ordering: {[Op.gt]: row.ordering}}});
+    const del = await db.topics.destroy({where: {id: req.query.id}});
+    const rows = await db.topics.findAll({where: {section_id: row.section_id}, attributes: ["id", "title", "slug", "ordering", "section_id", "type"], order: [["ordering", "ASC"]]});
+    res.json(rows);
   });
 
   app.post("/api/cms/storytopic/update", isEnabled, async(req, res) => {
-    db.storytopics.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
+    const u = await db.storytopics.update(req.body, {where: {id: req.body.id}});
+    res.json(u);
   });
 
   app.post("/api/cms/storytopic/new", isEnabled, async(req, res) => {
-    db.storytopics.create(req.body).then(u => res.json(u));
+    const u = await db.storytopics.create(req.body);
+    res.json(u);
   });
 
   app.delete("/api/cms/storytopic/delete", isEnabled, async(req, res) => {
-    db.storytopics.findOne({where: {id: req.query.id}}).then(row => {
-      db.storytopics.update({ordering: sequelize.literal("ordering -1")}, {where: {story_id: row.story_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
-        db.storytopics.destroy({where: {id: req.query.id}}).then(() => {
-          db.storytopics.findAll({where: {story_id: row.story_id}, attributes: ["id", "title", "slug", "ordering", "story_id", "type"], order: [["ordering", "ASC"]]}).then(rows => {
-            res.json(rows);
-          });
-        });
-      });
-    });
+    const row = await db.storytopics.findOne({where: {id: req.query.id}});
+    const up = await db.storytopics.update({ordering: sequelize.literal("ordering -1")}, {where: {story_id: row.story_id, ordering: {[Op.gt]: row.ordering}}});
+    const del = await db.storytopics.destroy({where: {id: req.query.id}});
+    const rows = await db.storytopics.findAll({where: {story_id: row.story_id}, attributes: ["id", "title", "slug", "ordering", "story_id", "type"], order: [["ordering", "ASC"]]});
+    res.json(rows);
   });
 
   app.post("/api/cms/topic_subtitle/update", isEnabled, async(req, res) => {
-    db.topics_subtitles.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
+    const u = await db.topics_subtitles.update(req.body, {where: {id: req.body.id}});
+    res.json(u);
   });
 
   app.post("/api/cms/topic_subtitle/new", isEnabled, async(req, res) => {
-    db.topics_subtitles.create(req.body).then(u => res.json(u));
+    const u = await db.topics_subtitles.create(req.body);
+    res.json(u);
   });
 
   app.delete("/api/cms/topic_subtitle/delete", isEnabled, async(req, res) => {
-    db.topics_subtitles.findOne({where: {id: req.query.id}}).then(row => {
-      db.topics_subtitles.update({ordering: sequelize.literal("ordering -1")}, {where: {topic_id: row.topic_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
-        db.topics_subtitles.destroy({where: {id: req.query.id}}).then(() => {
-          db.topics_subtitles.findAll({where: {topic_id: row.topic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).then(rows => {
-            res.json(rows);
-          });
-        });
-      });
-    });
+    const row = await db.topics_subtitles.findOne({where: {id: req.query.id}});
+    const up = await db.topics_subtitles.update({ordering: sequelize.literal("ordering -1")}, {where: {topic_id: row.topic_id, ordering: {[Op.gt]: row.ordering}}});
+    const del = await db.topics_subtitles.destroy({where: {id: req.query.id}});
+    const rows = await db.topics_subtitles.findAll({where: {topic_id: row.topic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]});
+    res.json(rows);
   });
 
   app.post("/api/cms/storytopic_subtitle/update", isEnabled, async(req, res) => {
-    db.storytopics_subtitles.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
+    const u = await db.storytopics_subtitles.update(req.body, {where: {id: req.body.id}});
+    res.json(u);
   });
 
   app.post("/api/cms/storytopic_subtitle/new", isEnabled, async(req, res) => {
-    db.storytopics_subtitles.create(req.body).then(u => res.json(u));
+    const u = await db.storytopics_subtitles.create(req.body);
+    res.json(u);
   });
 
   app.delete("/api/cms/storytopic_subtitle/delete", isEnabled, async(req, res) => {
-    db.storytopics_subtitles.findOne({where: {id: req.query.id}}).then(row => {
-      db.storytopics_subtitles.update({ordering: sequelize.literal("ordering -1")}, {where: {storytopic_id: row.storytopic_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
-        db.storytopics_subtitles.destroy({where: {id: req.query.id}}).then(() => {
-          db.storytopics_subtitles.findAll({where: {storytopic_id: row.storytopic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).then(rows => {
-            res.json(rows);
-          });
-        });
-      });
-    });
+    const row = await db.storytopics_subtitles.findOne({where: {id: req.query.id}});
+    const up = await db.storytopics_subtitles.update({ordering: sequelize.literal("ordering -1")}, {where: {storytopic_id: row.storytopic_id, ordering: {[Op.gt]: row.ordering}}});
+    const del = await db.storytopics_subtitles.destroy({where: {id: req.query.id}});
+    const rows = await db.storytopics_subtitles.findAll({where: {storytopic_id: row.storytopic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]});
+    res.json(rows);
   });
 
   app.post("/api/cms/topic_description/update", isEnabled, async(req, res) => {
-    db.topics_descriptions.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
+    const u = await db.topics_descriptions.update(req.body, {where: {id: req.body.id}});
+    res.json(u);
   });
 
   app.post("/api/cms/topic_description/new", isEnabled, async(req, res) => {
-    db.topics_descriptions.create(req.body).then(u => res.json(u));
+    const u = await db.topics_descriptions.create(req.body);
+    res.json(u);
   });
 
   app.delete("/api/cms/topic_description/delete", isEnabled, async(req, res) => {
-    db.topics_descriptions.findOne({where: {id: req.query.id}}).then(row => {
-      db.topics_descriptions.update({ordering: sequelize.literal("ordering -1")}, {where: {topic_id: row.topic_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
-        db.topics_descriptions.destroy({where: {id: req.query.id}}).then(() => {
-          db.topics_descriptions.findAll({where: {topic_id: row.topic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).then(rows => {
-            res.json(rows);
-          });
-        });
-      });
-    });
+    const row = await db.topics_descriptions.findOne({where: {id: req.query.id}});
+    const up = await db.topics_descriptions.update({ordering: sequelize.literal("ordering -1")}, {where: {topic_id: row.topic_id, ordering: {[Op.gt]: row.ordering}}});
+    const del = await db.topics_descriptions.destroy({where: {id: req.query.id}});
+    const rows = await db.topics_descriptions.findAll({where: {topic_id: row.topic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]});
+    res.json(rows);
   });
 
   app.post("/api/cms/storytopic_description/update", isEnabled, async(req, res) => {
-    db.storytopics_descriptions.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
+    const u = await db.storytopics_descriptions.update(req.body, {where: {id: req.body.id}});
+    res.json(u);
   });
 
   app.post("/api/cms/storytopic_description/new", isEnabled, async(req, res) => {
-    db.storytopics_descriptions.create(req.body).then(u => res.json(u));
+    const u = await db.storytopics_descriptions.create(req.body);
+    res.json(u);
   });
 
   app.delete("/api/cms/storytopic_description/delete", isEnabled, async(req, res) => {
-    db.storytopics_descriptions.findOne({where: {id: req.query.id}}).then(row => {
-      db.storytopics_descriptions.update({ordering: sequelize.literal("ordering -1")}, {where: {storytopic_id: row.storytopic_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
-        db.storytopics_descriptions.destroy({where: {id: req.query.id}}).then(() => {
-          db.storytopics_descriptions.findAll({where: {storytopic_id: row.storytopic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).then(rows => {
-            res.json(rows);
-          });
-        });
-      });
-    });
+    const row = await db.storytopics_descriptions.findOne({where: {id: req.query.id}});
+    const up = await db.storytopics_descriptions.update({ordering: sequelize.literal("ordering -1")}, {where: {storytopic_id: row.storytopic_id, ordering: {[Op.gt]: row.ordering}}});
+    const del = await db.storytopics_descriptions.destroy({where: {id: req.query.id}});
+    const rows = await db.storytopics_descriptions.findAll({where: {storytopic_id: row.storytopic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]});
+    res.json(rows);
   });
 
   app.post("/api/cms/selector/update", isEnabled, async(req, res) => {
-    db.selectors.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
+    const u = await db.selectors.update(req.body, {where: {id: req.body.id}});
+    res.json(u);
   });
 
   app.post("/api/cms/selector/new", isEnabled, async(req, res) => {
-    db.selectors.create(req.body).then(u => res.json(u));
+    const u = await db.selectors.create(req.body);
+    res.json(u);
   });
 
   app.delete("/api/cms/selector/delete", isEnabled, async(req, res) => {
-    db.selectors.findOne({where: {id: req.query.id}}).then(row => {
-      db.selectors.update({ordering: sequelize.literal("ordering -1")}, {where: {topic_id: row.topic_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
-        db.selectors.destroy({where: {id: req.query.id}}).then(() => {
-          db.selectors.findAll({where: {topic_id: row.topic_id}, order: [["ordering", "ASC"]]}).then(rows => {
-            res.json(rows);
-          });
-        });
-      });
-    });
+    const row = await db.selectors.findOne({where: {id: req.query.id}});
+    const up = await db.selectors.update({ordering: sequelize.literal("ordering -1")}, {where: {topic_id: row.topic_id, ordering: {[Op.gt]: row.ordering}}});
+    const del = await db.selectors.destroy({where: {id: req.query.id}});
+    const rows = await db.selectors.findAll({where: {topic_id: row.topic_id}, order: [["ordering", "ASC"]]});
+    res.json(rows);
   });
 
   app.post("/api/cms/profile_stat/update", isEnabled, async(req, res) => {
-    db.profiles_stats.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
+    const u = await db.profiles_stats.update(req.body, {where: {id: req.body.id}});
+    res.json(u);
   });
 
   app.post("/api/cms/profile_stat/new", isEnabled, async(req, res) => {
-    db.profiles_stats.create(req.body).then(u => res.json(u));
+    const u = await db.profiles_stats.create(req.body);
+    res.json(u);
   });
 
   app.delete("/api/cms/profile_stat/delete", isEnabled, async(req, res) => {
-    db.profiles_stats.findOne({where: {id: req.query.id}}).then(row => {
-      db.profiles_stats.update({ordering: sequelize.literal("ordering -1")}, {where: {profile_id: row.profile_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
-        db.profiles_stats.destroy({where: {id: req.query.id}}).then(() => {
-          db.profiles_stats.findAll({where: {profile_id: row.profile_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).then(rows => {
-            res.json(rows);
-          });
-        });
-      });
-    });
+    const row = await db.profiles_stats.findOne({where: {id: req.query.id}});
+    const up = await db.profiles_stats.update({ordering: sequelize.literal("ordering -1")}, {where: {profile_id: row.profile_id, ordering: {[Op.gt]: row.ordering}}});
+    const del = await db.profiles_stats.destroy({where: {id: req.query.id}});
+    const rows = await db.profiles_stats.findAll({where: {profile_id: row.profile_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]});
+    res.json(rows);
   });
 
   app.post("/api/cms/topic_stat/update", isEnabled, async(req, res) => {
-    db.topics_stats.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
+    const u = await db.topics_stats.update(req.body, {where: {id: req.body.id}});
+    res.json(u);
   });
 
   app.post("/api/cms/topic_stat/new", isEnabled, async(req, res) => {
-    db.topics_stats.create(req.body).then(u => res.json(u));
+    const u = await db.topics_stats.create(req.body);
+    res.json(u);
   });
 
   app.delete("/api/cms/topic_stat/delete", isEnabled, async(req, res) => {
-    db.topics_stats.findOne({where: {id: req.query.id}}).then(row => {
-      db.topics_stats.update({ordering: sequelize.literal("ordering -1")}, {where: {topic_id: row.topic_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
-        db.topics_stats.destroy({where: {id: req.query.id}}).then(() => {
-          db.topics_stats.findAll({where: {topic_id: row.topic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).then(rows => {
-            res.json(rows);
-          });
-        });
-      });
-    });
+    const row = await db.topics_stats.findOne({where: {id: req.query.id}});
+    const up = await db.topics_stats.update({ordering: sequelize.literal("ordering -1")}, {where: {topic_id: row.topic_id, ordering: {[Op.gt]: row.ordering}}});
+    const del = await db.topics_stats.destroy({where: {id: req.query.id}});
+    const rows = await db.topics_stats.findAll({where: {topic_id: row.topic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]});
+    res.json(rows);
   });
 
   app.post("/api/cms/storytopic_stat/update", isEnabled, async(req, res) => {
-    db.storytopics_stats.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
+    const u = await db.storytopics_stats.update(req.body, {where: {id: req.body.id}});
+    res.json(u);
   });
 
   app.post("/api/cms/storytopic_stat/new", isEnabled, async(req, res) => {
-    db.storytopics_stats.create(req.body).then(u => res.json(u));
+    const u = await db.storytopics_stats.create(req.body);
+    res.json(u);
   });
 
   app.delete("/api/cms/storytopic_stat/delete", isEnabled, async(req, res) => {
-    db.storytopics_stats.findOne({where: {id: req.query.id}}).then(row => {
-      db.storytopics_stats.update({ordering: sequelize.literal("ordering -1")}, {where: {storytopic_id: row.storytopic_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
-        db.storytopics_stats.destroy({where: {id: req.query.id}}).then(() => {
-          db.storytopics_stats.findAll({where: {storytopic_id: row.storytopic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).then(rows => {
-            res.json(rows);
-          });
-        });
-      });
-    });
+    const row = await db.storytopics_stats.findOne({where: {id: req.query.id}});
+    const up = await db.storytopics_stats.update({ordering: sequelize.literal("ordering -1")}, {where: {storytopic_id: row.storytopic_id, ordering: {[Op.gt]: row.ordering}}});
+    const del = await db.storytopics_stats.destroy({where: {id: req.query.id}});
+    const rows = await db.storytopics_stats.findAll({where: {storytopic_id: row.storytopic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]});
+    res.json(rows);
   });
 
   app.post("/api/cms/profile_visualization/update", isEnabled, async(req, res) => {
-    db.profiles_visualizations.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
+    const u = await db.profiles_visualizations.update(req.body, {where: {id: req.body.id}});
+    res.json(u);
   });
 
   app.post("/api/cms/profile_visualization/new", isEnabled, async(req, res) => {
-    db.profiles_visualizations.create(req.body).then(u => res.json(u));
+    const u = await db.profiles_visualizations.create(req.body);
+    res.json(u);
   });
 
   app.delete("/api/cms/profile_visualization/delete", isEnabled, async(req, res) => {
-    db.profiles_visualizations.findOne({where: {id: req.query.id}}).then(row => {
-      db.profiles_visualizations.update({ordering: sequelize.literal("ordering -1")}, {where: {profile_id: row.profile_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
-        db.profiles_visualizations.destroy({where: {id: req.query.id}}).then(() => {
-          db.profiles_visualizations.findAll({where: {profile_id: row.profile_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).then(rows => {
-            res.json(rows);
-          });
-        });
-      });
-    });
+    const row = await db.profiles_visualizations.findOne({where: {id: req.query.id}});
+    const up = await db.profiles_visualizations.update({ordering: sequelize.literal("ordering -1")}, {where: {profile_id: row.profile_id, ordering: {[Op.gt]: row.ordering}}});
+    const del = await db.profiles_visualizations.destroy({where: {id: req.query.id}});
+    const rows = await db.profiles_visualizations.findAll({where: {profile_id: row.profile_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]});
+    res.json(rows);
   });
 
   app.post("/api/cms/topic_visualization/update", isEnabled, async(req, res) => {
-    db.topics_visualizations.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
+    const u = await db.topics_visualizations.update(req.body, {where: {id: req.body.id}});
+    res.json(u);
   });
 
   app.post("/api/cms/topic_visualization/new", isEnabled, async(req, res) => {
-    db.topics_visualizations.create(req.body).then(u => res.json(u));
+    const u = await db.topics_visualizations.create(req.body);
+    res.json(u);
   });
 
   app.delete("/api/cms/topic_visualization/delete", isEnabled, async(req, res) => {
-    db.topics_visualizations.findOne({where: {id: req.query.id}}).then(row => {
-      db.topics_visualizations.update({ordering: sequelize.literal("ordering -1")}, {where: {topic_id: row.topic_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
-        db.topics_visualizations.destroy({where: {id: req.query.id}}).then(() => {
-          db.topics_visualizations.findAll({where: {topic_id: row.topic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).then(rows => {
-            res.json(rows);
-          });
-        });
-      });
-    });
+    const row = await db.topics_visualizations.findOne({where: {id: req.query.id}});
+    const up = await db.topics_visualizations.update({ordering: sequelize.literal("ordering -1")}, {where: {topic_id: row.topic_id, ordering: {[Op.gt]: row.ordering}}});
+    const del = await db.topics_visualizations.destroy({where: {id: req.query.id}});
+    const rows = await db.topics_visualizations.findAll({where: {topic_id: row.topic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]});
+    res.json(rows);
   });
 
   app.post("/api/cms/storytopic_visualization/update", isEnabled, async(req, res) => {
-    db.storytopics_visualizations.update(req.body, {where: {id: req.body.id}}).then(u => res.json(u));
+    const u = await db.storytopics_visualizations.update(req.body, {where: {id: req.body.id}});
+    res.json(u);
   });
 
   app.post("/api/cms/storytopic_visualization/new", isEnabled, async(req, res) => {
-    db.storytopics_visualizations.create(req.body).then(u => res.json(u));
+    const u = await db.storytopics_visualizations.create(req.body);
+    res.json(u);
   });
 
   app.delete("/api/cms/storytopic_visualization/delete", isEnabled, async(req, res) => {
-    db.storytopics_visualizations.findOne({where: {id: req.query.id}}).then(row => {
-      db.storytopics_visualizations.update({ordering: sequelize.literal("ordering -1")}, {where: {storytopic_id: row.storytopic_id, ordering: {[Op.gt]: row.ordering}}}).then(() => {
-        db.storytopics_visualizations.destroy({where: {id: req.query.id}}).then(() => {
-          db.storytopics_visualizations.findAll({where: {storytopic_id: row.storytopic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).then(rows => {
-            res.json(rows);
-          });
-        });
-      });
-    });
+    const row = await db.storytopics_visualizations.findOne({where: {id: req.query.id}});
+    const up = await db.storytopics_visualizations.update({ordering: sequelize.literal("ordering -1")}, {where: {storytopic_id: row.storytopic_id, ordering: {[Op.gt]: row.ordering}}});
+    const del = await db.storytopics_visualizations.destroy({where: {id: req.query.id}});
+    const rows = await db.storytopics_visualizations.findAll({where: {storytopic_id: row.storytopic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]});
+    res.json(rows);
   });
 
 };

--- a/api/cmsRoute.js
+++ b/api/cmsRoute.js
@@ -12,6 +12,8 @@ const isEnabled = (req, res, next) => {
   return res.status(401).send("Not Authorized");
 };
 
+const catcher = () => [];
+
 const profileReqTreeOnly = {
   attributes: ["id", "title", "slug", "ordering"],
   include: [
@@ -142,13 +144,13 @@ module.exports = function(app) {
   });
 
   app.get("/api/cms/tree", async(req, res) => {
-    let profiles = await db.profiles.findAll(profileReqTreeOnly);
+    let profiles = await db.profiles.findAll(profileReqTreeOnly).catch(catcher);
     profiles = sortProfileTree(profiles);
     res.json(profiles);
   });
 
   app.get("/api/cms/storytree", async(req, res) => {
-    let stories = await db.stories.findAll(storyReqTreeOnly);
+    let stories = await db.stories.findAll(storyReqTreeOnly).catch(catcher);
     stories = sortStoryTree(stories);
     res.json(stories);
   });
@@ -156,28 +158,28 @@ module.exports = function(app) {
   app.get("/api/cms/profile/get/:id", async(req, res) => {
     const {id} = req.params;
     const reqObj = Object.assign({}, profileReqProfileOnly, {where: {id}});
-    const profile = await db.profiles.findOne(reqObj);
+    const profile = await db.profiles.findOne(reqObj).catch(catcher);
     res.json(sortProfile(profile));
   });
 
   app.get("/api/cms/story/get/:id", async(req, res) => {
     const {id} = req.params;
     const reqObj = Object.assign({}, storyReqStoryOnly, {where: {id}});
-    const story = await db.stories.findOne(reqObj);
+    const story = await db.stories.findOne(reqObj).catch(catcher);
     res.json(sortStory(story));
   });
 
   app.get("/api/cms/section/get/:id", async(req, res) => {
     const {id} = req.params;
     const reqObj = Object.assign({}, sectionReqSectionOnly, {where: {id}});
-    const section = await db.sections.findOne(reqObj);
+    const section = await db.sections.findOne(reqObj).catch(catcher);
     res.json(sortSection(section));
   });
 
   app.get("/api/cms/topic/get/:id", async(req, res) => {
     const {id} = req.params;
     const reqObj = Object.assign({}, topicReqTopicOnly, {where: {id}});
-    let topic = await db.topics.findOne(reqObj);
+    let topic = await db.topics.findOne(reqObj).catch(catcher);
     const topicTypes = [];
     shell.ls(`${topicTypeDir}*.jsx`).forEach(file => {
       const compName = file.replace(topicTypeDir, "").replace(".jsx", "");
@@ -191,7 +193,7 @@ module.exports = function(app) {
   app.get("/api/cms/storytopic/get/:id", async(req, res) => {
     const {id} = req.params;
     const reqObj = Object.assign({}, storyTopicReqStoryTopicOnly, {where: {id}});
-    let storytopic = await db.storytopics.findOne(reqObj);
+    let storytopic = await db.storytopics.findOne(reqObj).catch(catcher);
     const topicTypes = [];
     shell.ls(`${topicTypeDir}*.jsx`).forEach(file => {
       const compName = file.replace(topicTypeDir, "").replace(".jsx", "");
@@ -203,267 +205,267 @@ module.exports = function(app) {
   });
 
   app.get("/api/cms/generator/get/:id", async(req, res) => {
-    const u = await db.generators.findOne({where: {id: req.params.id}});
+    const u = await db.generators.findOne({where: {id: req.params.id}}).catch(catcher);
     res.json(u);
   });
 
   app.get("/api/cms/materializer/get/:id", async(req, res) => {
-    const u = await db.materializers.findOne({where: {id: req.params.id}});
+    const u = await db.materializers.findOne({where: {id: req.params.id}}).catch(catcher);
     res.json(u);
   });
 
   app.get("/api/cms/profile_stat/get/:id", async(req, res) => {
-    const u = await db.profiles_stats.findOne({where: {id: req.params.id}});
+    const u = await db.profiles_stats.findOne({where: {id: req.params.id}}).catch(catcher);
     res.json(u);
   });
 
   app.get("/api/cms/profile_visualization/get/:id", async(req, res) => {
-    const u = await db.profiles_visualizations.findOne({where: {id: req.params.id}});
+    const u = await db.profiles_visualizations.findOne({where: {id: req.params.id}}).catch(catcher);
     res.json(u);
   });
 
   app.get("/api/cms/profile_description/get/:id", async(req, res) => {
-    const u = await db.profiles_descriptions.findOne({where: {id: req.params.id}});
+    const u = await db.profiles_descriptions.findOne({where: {id: req.params.id}}).catch(catcher);
     res.json(u);
   });
 
   app.get("/api/cms/story_description/get/:id", async(req, res) => {
-    const u = await db.stories_descriptions.findOne({where: {id: req.params.id}});
+    const u = await db.stories_descriptions.findOne({where: {id: req.params.id}}).catch(catcher);
     res.json(u);
   });
 
   // not sure if we need this - will footnote editing be a singular list, therefore not requiring piecemeal gets?
   app.get("/api/cms/story_footnote/get/:id", async(req, res) => {
-    const u = await db.stories_footnotes.findOne({where: {id: req.params.id}});
+    const u = await db.stories_footnotes.findOne({where: {id: req.params.id}}).catch(catcher);
     res.json(u);
   });
 
   app.get("/api/cms/author/get/:id", async(req, res) => {
-    const u = await db.authors.findOne({where: {id: req.params.id}});
+    const u = await db.authors.findOne({where: {id: req.params.id}}).catch(catcher);
     res.json(u);
   });
 
   app.get("/api/cms/section_subtitle/get/:id", async(req, res) => {
-    const u = await db.sections_subtitles.findOne({where: {id: req.params.id}});
+    const u = await db.sections_subtitles.findOne({where: {id: req.params.id}}).catch(catcher);
     res.json(u);
   });
 
   app.get("/api/cms/section_description/get/:id", async(req, res) => {
-    const u = await db.sections_descriptions.findOne({where: {id: req.params.id}});
+    const u = await db.sections_descriptions.findOne({where: {id: req.params.id}}).catch(catcher);
     res.json(u);
   });
 
   app.get("/api/cms/topic_subtitle/get/:id", async(req, res) => {
-    const u = await db.topics_subtitles.findOne({where: {id: req.params.id}});
+    const u = await db.topics_subtitles.findOne({where: {id: req.params.id}}).catch(catcher);
     res.json(u);
   });
 
   app.get("/api/cms/topic_description/get/:id", async(req, res) => {
-    const u = await db.topics_descriptions.findOne({where: {id: req.params.id}});
+    const u = await db.topics_descriptions.findOne({where: {id: req.params.id}}).catch(catcher);
     res.json(u);
   });
 
   app.get("/api/cms/topic_stat/get/:id", async(req, res) => {
-    const u = await db.topics_stats.findOne({where: {id: req.params.id}});
+    const u = await db.topics_stats.findOne({where: {id: req.params.id}}).catch(catcher);
     res.json(u);
   });
 
   app.get("/api/cms/topic_visualization/get/:id", async(req, res) => {
-    const u = await db.topics_visualizations.findOne({where: {id: req.params.id}});
+    const u = await db.topics_visualizations.findOne({where: {id: req.params.id}}).catch(catcher);
     res.json(u);
   });
 
   app.get("/api/cms/selector/get/:id", async(req, res) => {
-    const u = await db.selectors.findOne({where: {id: req.params.id}});
+    const u = await db.selectors.findOne({where: {id: req.params.id}}).catch(catcher);
     res.json(u);
   });
 
   app.get("/api/cms/storytopic_subtitle/get/:id", async(req, res) => {
-    const u = await db.storytopics_subtitles.findOne({where: {id: req.params.id}});
+    const u = await db.storytopics_subtitles.findOne({where: {id: req.params.id}}).catch(catcher);
     res.json(u);
   });
 
   app.get("/api/cms/storytopic_description/get/:id", async(req, res) => {
-    const u = await db.storytopics_descriptions.findOne({where: {id: req.params.id}});
+    const u = await db.storytopics_descriptions.findOne({where: {id: req.params.id}}).catch(catcher);
     res.json(u);
   });
 
   app.get("/api/cms/storytopic_stat/get/:id", async(req, res) => {
-    const u = await db.storytopics_stats.findOne({where: {id: req.params.id}});
+    const u = await db.storytopics_stats.findOne({where: {id: req.params.id}}).catch(catcher);
     res.json(u);
   });
 
   app.get("/api/cms/storytopic_visualization/get/:id", async(req, res) => {
-    const u = await db.storytopics_visualizations.findOne({where: {id: req.params.id}});
+    const u = await db.storytopics_visualizations.findOne({where: {id: req.params.id}}).catch(catcher);
     res.json(u);
   });
 
   /* END PIECEMEAL CMS API GETS */
 
   app.post("/api/cms/generator/new", isEnabled, async(req, res) => {
-    const u = await db.generators.create(req.body);
+    const u = await db.generators.create(req.body).catch(catcher);
     res.json(u);
   });
 
   app.post("/api/cms/generator/update", isEnabled, async(req, res) => {
-    const u = await db.generators.update(req.body, {where: {id: req.body.id}});
+    const u = await db.generators.update(req.body, {where: {id: req.body.id}}).catch(catcher);
     res.json(u);
   });
 
   // testme
   app.delete("/api/cms/generator/delete", isEnabled, async(req, res) => {
-    const row = await db.generators.findOne({where: {id: req.query.id}});
-    const del = await db.generators.destroy({where: {id: req.query.id}});
-    const rows = await db.generators.findAll({where: {profile_id: row.profile_id}, attributes: ["id", "name"]});
+    const row = await db.generators.findOne({where: {id: req.query.id}}).catch(catcher);
+    const del = await db.generators.destroy({where: {id: req.query.id}}).catch(catcher);
+    const rows = await db.generators.findAll({where: {profile_id: row.profile_id}, attributes: ["id", "name"]}).catch(catcher);
     res.json(rows);
   });
 
   app.post("/api/cms/materializer/new", isEnabled, async(req, res) => {
-    const u = await db.materializers.create(req.body);
+    const u = await db.materializers.create(req.body).catch(catcher);
     res.json(u);
   });
 
   app.post("/api/cms/materializer/update", isEnabled, async(req, res) => {
-    const u = await db.materializers.update(req.body, {where: {id: req.body.id}});
+    const u = await db.materializers.update(req.body, {where: {id: req.body.id}}).catch(catcher);
     res.json(u);
   });
 
   // testme
   app.delete("/api/cms/materializer/delete", isEnabled, async(req, res) => {
-    const row = await db.materializers.findOne({where: {id: req.query.id}});
-    const up = await db.materializers.update({ordering: sequelize.literal("ordering -1")}, {where: {profile_id: row.profile_id, ordering: {[Op.gt]: row.ordering}}});
-    const del = await db.materializers.destroy({where: {id: req.query.id}});
-    const rows = await db.materializers.findAll({where: {profile_id: row.profile_id}, attributes: ["id", "ordering", "name"], order: [["ordering", "ASC"]]});
+    const row = await db.materializers.findOne({where: {id: req.query.id}}).catch(catcher);
+    const up = await db.materializers.update({ordering: sequelize.literal("ordering -1")}, {where: {profile_id: row.profile_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    const del = await db.materializers.destroy({where: {id: req.query.id}}).catch(catcher);
+    const rows = await db.materializers.findAll({where: {profile_id: row.profile_id}, attributes: ["id", "ordering", "name"], order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
 
   app.post("/api/cms/profile/update", isEnabled, async(req, res) => {
-    const u = await db.profiles.update(req.body, {where: {id: req.body.id}});
+    const u = await db.profiles.update(req.body, {where: {id: req.body.id}}).catch(catcher);
     res.json(u);
   });
 
   app.post("/api/cms/profile/new", isEnabled, async(req, res) => {
-    const u = await db.profiles.create(req.body);
+    const u = await db.profiles.create(req.body).catch(catcher);
     res.json(u);
   });
 
   // testme
   app.delete("/api/cms/profile/delete", isEnabled, async(req, res) => {
-    const row = await db.profiles.findOne({where: {id: req.query.id}});
-    const up = await db.profiles.update({ordering: sequelize.literal("ordering -1")}, {where: {ordering: {[Op.gt]: row.ordering}}});
-    const del = await db.profiles.destroy({where: {id: req.query.id}});
-    let profiles = await db.profiles.findAll(profileReqTreeOnly);
+    const row = await db.profiles.findOne({where: {id: req.query.id}}).catch(catcher);
+    const up = await db.profiles.update({ordering: sequelize.literal("ordering -1")}, {where: {ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    const del = await db.profiles.destroy({where: {id: req.query.id}}).catch(catcher);
+    let profiles = await db.profiles.findAll(profileReqTreeOnly).catch(catcher);
     profiles = sortProfileTree(profiles);
     res.json(profiles);
   });
 
   app.post("/api/cms/story/update", isEnabled, async(req, res) => {
-    const u = await db.stories.update(req.body, {where: {id: req.body.id}});
+    const u = await db.stories.update(req.body, {where: {id: req.body.id}}).catch(catcher);
     res.json(u);
   });
 
   app.post("/api/cms/story/new", isEnabled, async(req, res) => {
-    const u = await db.stories.create(req.body);
+    const u = await db.stories.create(req.body).catch(catcher);
     res.json(u);
   });
 
   // testme
   app.delete("/api/cms/story/delete", isEnabled, async(req, res) => {
-    const row = await db.stories.findOne({where: {id: req.query.id}})
-    const up = await db.stories.update({ordering: sequelize.literal("ordering -1")}, {where: {ordering: {[Op.gt]: row.ordering}}});
-    const del = await db.stories.destroy({where: {id: req.query.id}});      
-    let stories = await db.stories.findAll(storyReqTreeOnly);
+    const row = await db.stories.findOne({where: {id: req.query.id}}).catch(catcher);
+    const up = await db.stories.update({ordering: sequelize.literal("ordering -1")}, {where: {ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    const del = await db.stories.destroy({where: {id: req.query.id}}).catch(catcher);      
+    let stories = await db.stories.findAll(storyReqTreeOnly).catch(catcher);
     stories = sortStoryTree(stories);
     res.json(stories);
   });
 
   app.post("/api/cms/author/update", isEnabled, async(req, res) => {
-    const u = await db.authors.update(req.body, {where: {id: req.body.id}});
+    const u = await db.authors.update(req.body, {where: {id: req.body.id}}).catch(catcher);
     res.json(u);
   });
 
   app.post("/api/cms/author/new", isEnabled, async(req, res) => {
-    const u = await db.authors.create(req.body);
+    const u = await db.authors.create(req.body).catch(catcher);
     res.json(u);
   });
 
   app.delete("/api/cms/author/delete", isEnabled, async(req, res) => {
-    const row = await db.authors.findOne({where: {id: req.query.id}});
-    const up = await db.authors.update({ordering: sequelize.literal("ordering -1")}, {where: {story_id: row.story_id, ordering: {[Op.gt]: row.ordering}}});
-    const del = await db.authors.destroy({where: {id: req.query.id}});
-    const rows = await db.authors.findAll({where: {story_id: row.story_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]});
+    const row = await db.authors.findOne({where: {id: req.query.id}}).catch(catcher);
+    const up = await db.authors.update({ordering: sequelize.literal("ordering -1")}, {where: {story_id: row.story_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    const del = await db.authors.destroy({where: {id: req.query.id}}).catch(catcher);
+    const rows = await db.authors.findAll({where: {story_id: row.story_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
 
   app.post("/api/cms/profile_description/update", isEnabled, async(req, res) => {
-    const u = await db.profiles_descriptions.update(req.body, {where: {id: req.body.id}});
+    const u = await db.profiles_descriptions.update(req.body, {where: {id: req.body.id}}).catch(catcher);
     res.json(u);
   });
 
   app.post("/api/cms/profile_description/new", isEnabled, async(req, res) => {
-    const u = await db.profiles_descriptions.create(req.body);
+    const u = await db.profiles_descriptions.create(req.body).catch(catcher);
     res.json(u);
   });
 
   // testme
   app.delete("/api/cms/profile_description/delete", isEnabled, async(req, res) => {
-    const row = await db.profiles_descriptions.findOne({where: {id: req.query.id}});
-    const up = await db.profiles_descriptions.update({ordering: sequelize.literal("ordering -1")}, {where: {profile_id: row.profile_id, ordering: {[Op.gt]: row.ordering}}});
-    const del = await db.profiles_descriptions.destroy({where: {id: req.query.id}});
-    const rows = await db.profiles_descriptions.findAll({where: {profile_id: row.profile_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]});
+    const row = await db.profiles_descriptions.findOne({where: {id: req.query.id}}).catch(catcher);
+    const up = await db.profiles_descriptions.update({ordering: sequelize.literal("ordering -1")}, {where: {profile_id: row.profile_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    const del = await db.profiles_descriptions.destroy({where: {id: req.query.id}}).catch(catcher);
+    const rows = await db.profiles_descriptions.findAll({where: {profile_id: row.profile_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
 
   app.post("/api/cms/story_description/update", isEnabled, async(req, res) => {
-    const u = await db.stories_descriptions.update(req.body, {where: {id: req.body.id}});
+    const u = await db.stories_descriptions.update(req.body, {where: {id: req.body.id}}).catch(catcher);
     res.json(u);
   });
 
   app.post("/api/cms/story_description/new", isEnabled, async(req, res) => {
-    const u = await db.stories_descriptions.create(req.body);
+    const u = await db.stories_descriptions.create(req.body).catch(catcher);
     res.json(u);
   });
 
   app.delete("/api/cms/story_description/delete", isEnabled, async(req, res) => {
-    const row = await db.stories_descriptions.findOne({where: {id: req.query.id}});
-    const up = await db.stories_descriptions.update({ordering: sequelize.literal("ordering -1")}, {where: {story_id: row.story_id, ordering: {[Op.gt]: row.ordering}}});
-    const del = await db.stories_descriptions.destroy({where: {id: req.query.id}});
-    const rows = await db.stories_descriptions.findAll({where: {story_id: row.story_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]});
+    const row = await db.stories_descriptions.findOne({where: {id: req.query.id}}).catch(catcher);
+    const up = await db.stories_descriptions.update({ordering: sequelize.literal("ordering -1")}, {where: {story_id: row.story_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    const del = await db.stories_descriptions.destroy({where: {id: req.query.id}}).catch(catcher);
+    const rows = await db.stories_descriptions.findAll({where: {story_id: row.story_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
 
   app.post("/api/cms/story_footnote/update", isEnabled, async(req, res) => {
-    const u = await db.stories_footnotes.update(req.body, {where: {id: req.body.id}});
+    const u = await db.stories_footnotes.update(req.body, {where: {id: req.body.id}}).catch(catcher);
     res.json(u);
   });
 
   app.post("/api/cms/story_footnote/new", isEnabled, async(req, res) => {
-    const u = await db.stories_footnotes.create(req.body);
+    const u = await db.stories_footnotes.create(req.body).catch(catcher);
     res.json(u);
   });
 
   app.delete("/api/cms/story_footnote/delete", isEnabled, async(req, res) => {
-    const row = await db.stories_footnotes.findOne({where: {id: req.query.id}});
-    const up = await db.stories_footnotes.update({ordering: sequelize.literal("ordering -1")}, {where: {story_id: row.story_id, ordering: {[Op.gt]: row.ordering}}});
-    const del = await db.stories_footnotes.destroy({where: {id: req.query.id}});
-    const rows = await db.stories_footnotes.findAll({where: {story_id: row.story_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]});
+    const row = await db.stories_footnotes.findOne({where: {id: req.query.id}}).catch(catcher);
+    const up = await db.stories_footnotes.update({ordering: sequelize.literal("ordering -1")}, {where: {story_id: row.story_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    const del = await db.stories_footnotes.destroy({where: {id: req.query.id}}).catch(catcher);
+    const rows = await db.stories_footnotes.findAll({where: {story_id: row.story_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
 
   app.post("/api/cms/section/update", isEnabled, async(req, res) => {
-    const u = await db.sections.update(req.body, {where: {id: req.body.id}});
+    const u = await db.sections.update(req.body, {where: {id: req.body.id}}).catch(catcher);
     res.json(u);
   });
 
   app.post("/api/cms/section/new", isEnabled, async(req, res) => {
-    const u = await db.sections.create(req.body);
+    const u = await db.sections.create(req.body).catch(catcher);
     res.json(u);
   });
 
   app.delete("/api/cms/section/delete", isEnabled, async(req, res) => {
-    const row = await db.sections.findOne({where: {id: req.query.id}});
-    const up = await db.sections.update({ordering: sequelize.literal("ordering -1")}, {where: {profile_id: row.profile_id, ordering: {[Op.gt]: row.ordering}}});
-    const del = await db.sections.destroy({where: {id: req.query.id}});
+    const row = await db.sections.findOne({where: {id: req.query.id}}).catch(catcher);
+    const up = await db.sections.update({ordering: sequelize.literal("ordering -1")}, {where: {profile_id: row.profile_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    const del = await db.sections.destroy({where: {id: req.query.id}}).catch(catcher);
     const rows = await db.sections.findAll({
       where: {profile_id: row.profile_id},
       attributes: ["id", "title", "slug", "ordering", "profile_id"],
@@ -471,133 +473,133 @@ module.exports = function(app) {
       include: [
         {association: "topics", attributes: ["id", "title", "slug", "ordering", "section_id"]}
       ]
-    });
+    }).catch(catcher);
     res.json(rows);
   });
 
   app.post("/api/cms/section_subtitle/update", isEnabled, async(req, res) => {
-    const u = await db.sections_subtitles.update(req.body, {where: {id: req.body.id}});
+    const u = await db.sections_subtitles.update(req.body, {where: {id: req.body.id}}).catch(catcher);
     res.json(u);
   });
 
   app.post("/api/cms/section_subtitle/new", isEnabled, async(req, res) => {
-    const u = await db.sections_subtitles.create(req.body);
+    const u = await db.sections_subtitles.create(req.body).catch(catcher);
     res.json(u);
   });
 
   app.delete("/api/cms/section_subtitle/delete", isEnabled, async(req, res) => {
-    const row = await db.sections_subtitles.findOne({where: {id: req.query.id}});
-    const up = await db.sections_subtitles.update({ordering: sequelize.literal("ordering -1")}, {where: {section_id: row.section_id, ordering: {[Op.gt]: row.ordering}}});
-    const del = await db.sections_subtitles.destroy({where: {id: req.query.id}});
-    const rows = await db.sections_subtitles.findAll({where: {section_id: row.section_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]});
+    const row = await db.sections_subtitles.findOne({where: {id: req.query.id}}).catch(catcher);
+    const up = await db.sections_subtitles.update({ordering: sequelize.literal("ordering -1")}, {where: {section_id: row.section_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    const del = await db.sections_subtitles.destroy({where: {id: req.query.id}}).catch(catcher);
+    const rows = await db.sections_subtitles.findAll({where: {section_id: row.section_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
 
   app.post("/api/cms/section_description/update", isEnabled, async(req, res) => {
-    const u = await db.sections_descriptions.update(req.body, {where: {id: req.body.id}});
+    const u = await db.sections_descriptions.update(req.body, {where: {id: req.body.id}}).catch(catcher);
     res.json(u);
   });
 
   app.post("/api/cms/section_description/new", isEnabled, async(req, res) => {
-    const u = await db.sections_descriptions.create(req.body);
+    const u = await db.sections_descriptions.create(req.body).catch(catcher);
     res.json(u);
   });
 
   app.delete("/api/cms/section_description/delete", isEnabled, async(req, res) => {
-    const row = await db.sections_descriptions.findOne({where: {id: req.query.id}});
-    const up = await db.sections_descriptions.update({ordering: sequelize.literal("ordering -1")}, {where: {section_id: row.section_id, ordering: {[Op.gt]: row.ordering}}});
-    const del = await db.sections_descriptions.destroy({where: {id: req.query.id}});
-    const rows = await db.sections_descriptions.findAll({where: {section_id: row.section_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]});
+    const row = await db.sections_descriptions.findOne({where: {id: req.query.id}}).catch(catcher);
+    const up = await db.sections_descriptions.update({ordering: sequelize.literal("ordering -1")}, {where: {section_id: row.section_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    const del = await db.sections_descriptions.destroy({where: {id: req.query.id}}).catch(catcher);
+    const rows = await db.sections_descriptions.findAll({where: {section_id: row.section_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
 
   app.post("/api/cms/topic/update", isEnabled, async(req, res) => {
-    const u = await db.topics.update(req.body, {where: {id: req.body.id}});
+    const u = await db.topics.update(req.body, {where: {id: req.body.id}}).catch(catcher);
     res.json(u);
   });
 
   app.post("/api/cms/topic/new", isEnabled, async(req, res) => {
-    const u = await db.topics.create(req.body);
+    const u = await db.topics.create(req.body).catch(catcher);
     res.json(u);
   });
 
   app.delete("/api/cms/topic/delete", isEnabled, async(req, res) => {
-    const row = await db.topics.findOne({where: {id: req.query.id}});
-    const up = await db.topics.update({ordering: sequelize.literal("ordering -1")}, {where: {section_id: row.section_id, ordering: {[Op.gt]: row.ordering}}});
-    const del = await db.topics.destroy({where: {id: req.query.id}});
-    const rows = await db.topics.findAll({where: {section_id: row.section_id}, attributes: ["id", "title", "slug", "ordering", "section_id", "type"], order: [["ordering", "ASC"]]});
+    const row = await db.topics.findOne({where: {id: req.query.id}}).catch(catcher);
+    const up = await db.topics.update({ordering: sequelize.literal("ordering -1")}, {where: {section_id: row.section_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    const del = await db.topics.destroy({where: {id: req.query.id}}).catch(catcher);
+    const rows = await db.topics.findAll({where: {section_id: row.section_id}, attributes: ["id", "title", "slug", "ordering", "section_id", "type"], order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
 
   app.post("/api/cms/storytopic/update", isEnabled, async(req, res) => {
-    const u = await db.storytopics.update(req.body, {where: {id: req.body.id}});
+    const u = await db.storytopics.update(req.body, {where: {id: req.body.id}}).catch(catcher);
     res.json(u);
   });
 
   app.post("/api/cms/storytopic/new", isEnabled, async(req, res) => {
-    const u = await db.storytopics.create(req.body);
+    const u = await db.storytopics.create(req.body).catch(catcher);
     res.json(u);
   });
 
   app.delete("/api/cms/storytopic/delete", isEnabled, async(req, res) => {
-    const row = await db.storytopics.findOne({where: {id: req.query.id}});
-    const up = await db.storytopics.update({ordering: sequelize.literal("ordering -1")}, {where: {story_id: row.story_id, ordering: {[Op.gt]: row.ordering}}});
-    const del = await db.storytopics.destroy({where: {id: req.query.id}});
-    const rows = await db.storytopics.findAll({where: {story_id: row.story_id}, attributes: ["id", "title", "slug", "ordering", "story_id", "type"], order: [["ordering", "ASC"]]});
+    const row = await db.storytopics.findOne({where: {id: req.query.id}}).catch(catcher);
+    const up = await db.storytopics.update({ordering: sequelize.literal("ordering -1")}, {where: {story_id: row.story_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    const del = await db.storytopics.destroy({where: {id: req.query.id}}).catch(catcher);
+    const rows = await db.storytopics.findAll({where: {story_id: row.story_id}, attributes: ["id", "title", "slug", "ordering", "story_id", "type"], order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
 
   app.post("/api/cms/topic_subtitle/update", isEnabled, async(req, res) => {
-    const u = await db.topics_subtitles.update(req.body, {where: {id: req.body.id}});
+    const u = await db.topics_subtitles.update(req.body, {where: {id: req.body.id}}).catch(catcher);
     res.json(u);
   });
 
   app.post("/api/cms/topic_subtitle/new", isEnabled, async(req, res) => {
-    const u = await db.topics_subtitles.create(req.body);
+    const u = await db.topics_subtitles.create(req.body).catch(catcher);
     res.json(u);
   });
 
   app.delete("/api/cms/topic_subtitle/delete", isEnabled, async(req, res) => {
-    const row = await db.topics_subtitles.findOne({where: {id: req.query.id}});
-    const up = await db.topics_subtitles.update({ordering: sequelize.literal("ordering -1")}, {where: {topic_id: row.topic_id, ordering: {[Op.gt]: row.ordering}}});
-    const del = await db.topics_subtitles.destroy({where: {id: req.query.id}});
-    const rows = await db.topics_subtitles.findAll({where: {topic_id: row.topic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]});
+    const row = await db.topics_subtitles.findOne({where: {id: req.query.id}}).catch(catcher);
+    const up = await db.topics_subtitles.update({ordering: sequelize.literal("ordering -1")}, {where: {topic_id: row.topic_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    const del = await db.topics_subtitles.destroy({where: {id: req.query.id}}).catch(catcher);
+    const rows = await db.topics_subtitles.findAll({where: {topic_id: row.topic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
 
   app.post("/api/cms/storytopic_subtitle/update", isEnabled, async(req, res) => {
-    const u = await db.storytopics_subtitles.update(req.body, {where: {id: req.body.id}});
+    const u = await db.storytopics_subtitles.update(req.body, {where: {id: req.body.id}}).catch(catcher);
     res.json(u);
   });
 
   app.post("/api/cms/storytopic_subtitle/new", isEnabled, async(req, res) => {
-    const u = await db.storytopics_subtitles.create(req.body);
+    const u = await db.storytopics_subtitles.create(req.body).catch(catcher);
     res.json(u);
   });
 
   app.delete("/api/cms/storytopic_subtitle/delete", isEnabled, async(req, res) => {
-    const row = await db.storytopics_subtitles.findOne({where: {id: req.query.id}});
-    const up = await db.storytopics_subtitles.update({ordering: sequelize.literal("ordering -1")}, {where: {storytopic_id: row.storytopic_id, ordering: {[Op.gt]: row.ordering}}});
-    const del = await db.storytopics_subtitles.destroy({where: {id: req.query.id}});
-    const rows = await db.storytopics_subtitles.findAll({where: {storytopic_id: row.storytopic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]});
+    const row = await db.storytopics_subtitles.findOne({where: {id: req.query.id}}).catch(catcher);
+    const up = await db.storytopics_subtitles.update({ordering: sequelize.literal("ordering -1")}, {where: {storytopic_id: row.storytopic_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    const del = await db.storytopics_subtitles.destroy({where: {id: req.query.id}}).catch(catcher);
+    const rows = await db.storytopics_subtitles.findAll({where: {storytopic_id: row.storytopic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
 
   app.post("/api/cms/topic_description/update", isEnabled, async(req, res) => {
-    const u = await db.topics_descriptions.update(req.body, {where: {id: req.body.id}});
+    const u = await db.topics_descriptions.update(req.body, {where: {id: req.body.id}}).catch(catcher);
     res.json(u);
   });
 
   app.post("/api/cms/topic_description/new", isEnabled, async(req, res) => {
-    const u = await db.topics_descriptions.create(req.body);
+    const u = await db.topics_descriptions.create(req.body).catch(catcher);
     res.json(u);
   });
 
   app.delete("/api/cms/topic_description/delete", isEnabled, async(req, res) => {
-    const row = await db.topics_descriptions.findOne({where: {id: req.query.id}});
-    const up = await db.topics_descriptions.update({ordering: sequelize.literal("ordering -1")}, {where: {topic_id: row.topic_id, ordering: {[Op.gt]: row.ordering}}});
-    const del = await db.topics_descriptions.destroy({where: {id: req.query.id}});
-    const rows = await db.topics_descriptions.findAll({where: {topic_id: row.topic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]});
+    const row = await db.topics_descriptions.findOne({where: {id: req.query.id}}).catch(catcher);
+    const up = await db.topics_descriptions.update({ordering: sequelize.literal("ordering -1")}, {where: {topic_id: row.topic_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    const del = await db.topics_descriptions.destroy({where: {id: req.query.id}}).catch(catcher);
+    const rows = await db.topics_descriptions.findAll({where: {topic_id: row.topic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
 
@@ -607,141 +609,141 @@ module.exports = function(app) {
   });
 
   app.post("/api/cms/storytopic_description/new", isEnabled, async(req, res) => {
-    const u = await db.storytopics_descriptions.create(req.body);
+    const u = await db.storytopics_descriptions.create(req.body).catch(catcher);
     res.json(u);
   });
 
   app.delete("/api/cms/storytopic_description/delete", isEnabled, async(req, res) => {
-    const row = await db.storytopics_descriptions.findOne({where: {id: req.query.id}});
-    const up = await db.storytopics_descriptions.update({ordering: sequelize.literal("ordering -1")}, {where: {storytopic_id: row.storytopic_id, ordering: {[Op.gt]: row.ordering}}});
-    const del = await db.storytopics_descriptions.destroy({where: {id: req.query.id}});
-    const rows = await db.storytopics_descriptions.findAll({where: {storytopic_id: row.storytopic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]});
+    const row = await db.storytopics_descriptions.findOne({where: {id: req.query.id}}).catch(catcher);
+    const up = await db.storytopics_descriptions.update({ordering: sequelize.literal("ordering -1")}, {where: {storytopic_id: row.storytopic_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    const del = await db.storytopics_descriptions.destroy({where: {id: req.query.id}}).catch(catcher);
+    const rows = await db.storytopics_descriptions.findAll({where: {storytopic_id: row.storytopic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
 
   app.post("/api/cms/selector/update", isEnabled, async(req, res) => {
-    const u = await db.selectors.update(req.body, {where: {id: req.body.id}});
+    const u = await db.selectors.update(req.body, {where: {id: req.body.id}}).catch(catcher);
     res.json(u);
   });
 
   app.post("/api/cms/selector/new", isEnabled, async(req, res) => {
-    const u = await db.selectors.create(req.body);
+    const u = await db.selectors.create(req.body).catch(catcher);
     res.json(u);
   });
 
   app.delete("/api/cms/selector/delete", isEnabled, async(req, res) => {
-    const row = await db.selectors.findOne({where: {id: req.query.id}});
-    const up = await db.selectors.update({ordering: sequelize.literal("ordering -1")}, {where: {topic_id: row.topic_id, ordering: {[Op.gt]: row.ordering}}});
-    const del = await db.selectors.destroy({where: {id: req.query.id}});
-    const rows = await db.selectors.findAll({where: {topic_id: row.topic_id}, order: [["ordering", "ASC"]]});
+    const row = await db.selectors.findOne({where: {id: req.query.id}}).catch(catcher);
+    const up = await db.selectors.update({ordering: sequelize.literal("ordering -1")}, {where: {topic_id: row.topic_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    const del = await db.selectors.destroy({where: {id: req.query.id}}).catch(catcher);
+    const rows = await db.selectors.findAll({where: {topic_id: row.topic_id}, order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
 
   app.post("/api/cms/profile_stat/update", isEnabled, async(req, res) => {
-    const u = await db.profiles_stats.update(req.body, {where: {id: req.body.id}});
+    const u = await db.profiles_stats.update(req.body, {where: {id: req.body.id}}).catch(catcher);
     res.json(u);
   });
 
   app.post("/api/cms/profile_stat/new", isEnabled, async(req, res) => {
-    const u = await db.profiles_stats.create(req.body);
+    const u = await db.profiles_stats.create(req.body).catch(catcher);
     res.json(u);
   });
 
   app.delete("/api/cms/profile_stat/delete", isEnabled, async(req, res) => {
-    const row = await db.profiles_stats.findOne({where: {id: req.query.id}});
-    const up = await db.profiles_stats.update({ordering: sequelize.literal("ordering -1")}, {where: {profile_id: row.profile_id, ordering: {[Op.gt]: row.ordering}}});
-    const del = await db.profiles_stats.destroy({where: {id: req.query.id}});
-    const rows = await db.profiles_stats.findAll({where: {profile_id: row.profile_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]});
+    const row = await db.profiles_stats.findOne({where: {id: req.query.id}}).catch(catcher);
+    const up = await db.profiles_stats.update({ordering: sequelize.literal("ordering -1")}, {where: {profile_id: row.profile_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    const del = await db.profiles_stats.destroy({where: {id: req.query.id}}).catch(catcher);
+    const rows = await db.profiles_stats.findAll({where: {profile_id: row.profile_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
 
   app.post("/api/cms/topic_stat/update", isEnabled, async(req, res) => {
-    const u = await db.topics_stats.update(req.body, {where: {id: req.body.id}});
+    const u = await db.topics_stats.update(req.body, {where: {id: req.body.id}}).catch(catcher);
     res.json(u);
   });
 
   app.post("/api/cms/topic_stat/new", isEnabled, async(req, res) => {
-    const u = await db.topics_stats.create(req.body);
+    const u = await db.topics_stats.create(req.body).catch(catcher);
     res.json(u);
   });
 
   app.delete("/api/cms/topic_stat/delete", isEnabled, async(req, res) => {
-    const row = await db.topics_stats.findOne({where: {id: req.query.id}});
-    const up = await db.topics_stats.update({ordering: sequelize.literal("ordering -1")}, {where: {topic_id: row.topic_id, ordering: {[Op.gt]: row.ordering}}});
-    const del = await db.topics_stats.destroy({where: {id: req.query.id}});
-    const rows = await db.topics_stats.findAll({where: {topic_id: row.topic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]});
+    const row = await db.topics_stats.findOne({where: {id: req.query.id}}).catch(catcher);
+    const up = await db.topics_stats.update({ordering: sequelize.literal("ordering -1")}, {where: {topic_id: row.topic_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    const del = await db.topics_stats.destroy({where: {id: req.query.id}}).catch(catcher);
+    const rows = await db.topics_stats.findAll({where: {topic_id: row.topic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
 
   app.post("/api/cms/storytopic_stat/update", isEnabled, async(req, res) => {
-    const u = await db.storytopics_stats.update(req.body, {where: {id: req.body.id}});
+    const u = await db.storytopics_stats.update(req.body, {where: {id: req.body.id}}).catch(catcher);
     res.json(u);
   });
 
   app.post("/api/cms/storytopic_stat/new", isEnabled, async(req, res) => {
-    const u = await db.storytopics_stats.create(req.body);
+    const u = await db.storytopics_stats.create(req.body).catch(catcher);
     res.json(u);
   });
 
   app.delete("/api/cms/storytopic_stat/delete", isEnabled, async(req, res) => {
-    const row = await db.storytopics_stats.findOne({where: {id: req.query.id}});
-    const up = await db.storytopics_stats.update({ordering: sequelize.literal("ordering -1")}, {where: {storytopic_id: row.storytopic_id, ordering: {[Op.gt]: row.ordering}}});
-    const del = await db.storytopics_stats.destroy({where: {id: req.query.id}});
-    const rows = await db.storytopics_stats.findAll({where: {storytopic_id: row.storytopic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]});
+    const row = await db.storytopics_stats.findOne({where: {id: req.query.id}}).catch(catcher);
+    const up = await db.storytopics_stats.update({ordering: sequelize.literal("ordering -1")}, {where: {storytopic_id: row.storytopic_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    const del = await db.storytopics_stats.destroy({where: {id: req.query.id}}).catch(catcher);
+    const rows = await db.storytopics_stats.findAll({where: {storytopic_id: row.storytopic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
 
   app.post("/api/cms/profile_visualization/update", isEnabled, async(req, res) => {
-    const u = await db.profiles_visualizations.update(req.body, {where: {id: req.body.id}});
+    const u = await db.profiles_visualizations.update(req.body, {where: {id: req.body.id}}).catch(catcher);
     res.json(u);
   });
 
   app.post("/api/cms/profile_visualization/new", isEnabled, async(req, res) => {
-    const u = await db.profiles_visualizations.create(req.body);
+    const u = await db.profiles_visualizations.create(req.body).catch(catcher);
     res.json(u);
   });
 
   app.delete("/api/cms/profile_visualization/delete", isEnabled, async(req, res) => {
-    const row = await db.profiles_visualizations.findOne({where: {id: req.query.id}});
-    const up = await db.profiles_visualizations.update({ordering: sequelize.literal("ordering -1")}, {where: {profile_id: row.profile_id, ordering: {[Op.gt]: row.ordering}}});
-    const del = await db.profiles_visualizations.destroy({where: {id: req.query.id}});
-    const rows = await db.profiles_visualizations.findAll({where: {profile_id: row.profile_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]});
+    const row = await db.profiles_visualizations.findOne({where: {id: req.query.id}}).catch(catcher);
+    const up = await db.profiles_visualizations.update({ordering: sequelize.literal("ordering -1")}, {where: {profile_id: row.profile_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    const del = await db.profiles_visualizations.destroy({where: {id: req.query.id}}).catch(catcher);
+    const rows = await db.profiles_visualizations.findAll({where: {profile_id: row.profile_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
 
   app.post("/api/cms/topic_visualization/update", isEnabled, async(req, res) => {
-    const u = await db.topics_visualizations.update(req.body, {where: {id: req.body.id}});
+    const u = await db.topics_visualizations.update(req.body, {where: {id: req.body.id}}).catch(catcher);
     res.json(u);
   });
 
   app.post("/api/cms/topic_visualization/new", isEnabled, async(req, res) => {
-    const u = await db.topics_visualizations.create(req.body);
+    const u = await db.topics_visualizations.create(req.body).catch(catcher);
     res.json(u);
   });
 
   app.delete("/api/cms/topic_visualization/delete", isEnabled, async(req, res) => {
-    const row = await db.topics_visualizations.findOne({where: {id: req.query.id}});
-    const up = await db.topics_visualizations.update({ordering: sequelize.literal("ordering -1")}, {where: {topic_id: row.topic_id, ordering: {[Op.gt]: row.ordering}}});
-    const del = await db.topics_visualizations.destroy({where: {id: req.query.id}});
-    const rows = await db.topics_visualizations.findAll({where: {topic_id: row.topic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]});
+    const row = await db.topics_visualizations.findOne({where: {id: req.query.id}}).catch(catcher);
+    const up = await db.topics_visualizations.update({ordering: sequelize.literal("ordering -1")}, {where: {topic_id: row.topic_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    const del = await db.topics_visualizations.destroy({where: {id: req.query.id}}).catch(catcher);
+    const rows = await db.topics_visualizations.findAll({where: {topic_id: row.topic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
 
   app.post("/api/cms/storytopic_visualization/update", isEnabled, async(req, res) => {
-    const u = await db.storytopics_visualizations.update(req.body, {where: {id: req.body.id}});
+    const u = await db.storytopics_visualizations.update(req.body, {where: {id: req.body.id}}).catch(catcher);
     res.json(u);
   });
 
   app.post("/api/cms/storytopic_visualization/new", isEnabled, async(req, res) => {
-    const u = await db.storytopics_visualizations.create(req.body);
+    const u = await db.storytopics_visualizations.create(req.body).catch(catcher);
     res.json(u);
   });
 
   app.delete("/api/cms/storytopic_visualization/delete", isEnabled, async(req, res) => {
-    const row = await db.storytopics_visualizations.findOne({where: {id: req.query.id}});
-    const up = await db.storytopics_visualizations.update({ordering: sequelize.literal("ordering -1")}, {where: {storytopic_id: row.storytopic_id, ordering: {[Op.gt]: row.ordering}}});
-    const del = await db.storytopics_visualizations.destroy({where: {id: req.query.id}});
-    const rows = await db.storytopics_visualizations.findAll({where: {storytopic_id: row.storytopic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]});
+    const row = await db.storytopics_visualizations.findOne({where: {id: req.query.id}}).catch(catcher);
+    const up = await db.storytopics_visualizations.update({ordering: sequelize.literal("ordering -1")}, {where: {storytopic_id: row.storytopic_id, ordering: {[Op.gt]: row.ordering}}}).catch(catcher);
+    const del = await db.storytopics_visualizations.destroy({where: {id: req.query.id}}).catch(catcher);
+    const rows = await db.storytopics_visualizations.findAll({where: {storytopic_id: row.storytopic_id}, attributes: ["id", "ordering"], order: [["ordering", "ASC"]]}).catch(catcher);
     res.json(rows);
   });
 


### PR DESCRIPTION
Refactors `cmsRoute` to use exclusively `await` to protect against memory leaks. Also adds a generic `catch` to every `sequelize` call. 