### PR TITLE
updates indicators, adds current hospitalization stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ npm-debug.log*
 node_modules
 static/datacovid19.json
 static/mobilitycovid19.json
+static/usacovid19.json
 
 # these static files will be generated on build
 /static/assets

--- a/api/coronavirusTracker.js
+++ b/api/coronavirusTracker.js
@@ -301,6 +301,11 @@ module.exports = function(app) {
     let state = rawData[0].state;
     let data = rawData.map((raw, i) => {
 
+      // Massachusetts makes use of a more specific definition and stat, which was propogated retroactively. Use when available.
+      const positiveStat = raw.positiveCasesViral ? "positiveCasesViral" : "positive";
+      const testStat = raw.totalTestResults ? "totalTestResults" : "total";
+      const hospitalizedStat = raw.hospitalizedCumulative ? "hospitalizedCumulative" : "hospitalized";
+
       const d = {};
       d.Date = raw.date;
 
@@ -310,18 +315,23 @@ module.exports = function(app) {
       }
       else if (i) {
         const prev = rawData[i - 1];
-        if (raw.positive < prev.positive) raw.positive = prev.positive;
+        if (raw[positiveStat] < prev[positiveStat]) raw[positiveStat] = prev[positiveStat];
         if (raw.death < prev.death) raw.death = prev.death;
-        if (raw.total < prev.total) raw.total = prev.total;
-        if (raw.hospitalized < prev.hospitalized) raw.hospitalized = prev.hospitalized;
-        d.ConfirmedGrowth = raw.positive - prev.positive;
+        if (raw[testStat] < prev[testStat]) raw[testStat] = prev[testStat];
+        if (raw[hospitalizedStat] < prev[hospitalizedStat]) raw[hospitalizedStat] = prev[hospitalizedStat];
+        d.ConfirmedGrowth = raw[positiveStat] - prev[positiveStat];
       }
 
-      d.Confirmed = raw.positive;
-      d.Tests = raw.total;
-      d.Hospitalized = raw.hospitalized;
+      d.Confirmed = raw[positiveStat];
+      d.Tests = raw[testStat];
+      d.Hospitalized = raw[hospitalizedStat];
       d.Deaths = raw.death;
-      d.PositivePct = raw.positive / raw.total * 100;
+      d.DeathsConfirmed = raw.deathConfirmed;
+      d.DeathsProbable = raw.deathProbable;
+      d.PositivePct = raw[positiveStat] / raw[testStat] * 100;
+      d.CurrentlyHospitalized = raw.hospitalizedCurrently;
+      d.CurrentlyInICU = raw.inIcuCurrently;
+      d.CurrentlyOnVentilator = raw.onVentilatorCurrently;
 
       d.Geography = states[raw.state];
       d["ID Geography"] = stateToDivision[raw.state];

--- a/app/pages/Coronavirus.css
+++ b/app/pages/Coronavirus.css
@@ -240,18 +240,19 @@
     & th.Trend, & td.Trend {
       min-width: auto;
     }
+    @media (max-width: 1350px) {
+      & th.Curve, & td.Curve {
+        display: none;
+      }
+    }
     @media (max-width: 1250px) {
+      & th.Tests, & td.Tests,
       & th.Hospitalized, & td.Hospitalized {
         display: none;
       }
     }
     @media (max-width: 1150px) {
-      & th.Tests, & td.Tests {
-        display: none;
-      }
-    }
-    @media (max-width: 1150px) {
-      & th.Curve, & td.Curve {
+      & th.CurrentlyHospitalized, & td.CurrentlyHospitalized {
         display: none;
       }
     }

--- a/app/pages/Coronavirus.css
+++ b/app/pages/Coronavirus.css
@@ -392,7 +392,7 @@
   & .TextViz {
     flex-flow: wrap;
     & .topic-content {
-      max-width: 300px;
+      max-width: 350px;
       @media (max-width: 768px) {
         margin-bottom: 25px;
         min-width: 100%;

--- a/app/pages/Coronavirus.jsx
+++ b/app/pages/Coronavirus.jsx
@@ -923,8 +923,8 @@ class Coronavirus extends Component {
           ["Total Deaths", commas(d.Deaths)]
         ];
         if (d.DeathsConfirmed && d.DeathsProbable) {
-          arr.push(["Confirmed Deaths", commas(d.DeathsConfirmed)]);
-          arr.push(["Probable Deaths", commas(d.DeathsProbable)]);
+          arr.push(["&nbsp;&nbsp;&nbsp;Confirmed Deaths", commas(d.DeathsConfirmed)]);
+          arr.push(["&nbsp;&nbsp;&nbsp;Probable Deaths", commas(d.DeathsProbable)]);
         }
         if (d.DeathsPC !== undefined) {
           arr.push(["Deaths per 100,000", formatAbbreviate(d.DeathsPC)]);
@@ -987,14 +987,14 @@ class Coronavirus extends Component {
           ]);
         }
         if (d.Hospitalized) {
-          arr.push(["Hospitalized patients", commas(d.Hospitalized)]);
+          arr.push(["Total Hospitalizations", commas(d.Hospitalized)]);
         }
         if (d.HospitalizedPC) {
-          arr.push(["Hospitalized patients per 100,000", formatAbbreviate(d.HospitalizedPC)]);
+          arr.push(["Hospitalizations per 100,000", formatAbbreviate(d.HospitalizedPC)]);
         }
-        if (d.CurrentlyHospitalized) arr.push(["Patients in hospital on this date", formatAbbreviate(d.CurrentlyHospitalized)]);
-        if (d.CurrentlyInICU) arr.push(["Patients in ICU on this date", formatAbbreviate(d.CurrentlyInICU)]);
-        if (d.CurrentlyOnVentilator) arr.push(["Patients on ventilator on this date", formatAbbreviate(d.CurrentlyOnVentilator)]);
+        if (d.CurrentlyHospitalized) arr.push(["Currently Hospitalized", formatAbbreviate(d.CurrentlyHospitalized)]);
+        if (d.CurrentlyInICU) arr.push(["Currently in ICU", formatAbbreviate(d.CurrentlyInICU)]);
+        if (d.CurrentlyOnVentilator) arr.push([`Currently on Ventilator${d.CurrentlyOnVentilator !== 1 ? "s" : ""}`, formatAbbreviate(d.CurrentlyOnVentilator)]);
         return arr;
       }
     };
@@ -1316,7 +1316,7 @@ class Coronavirus extends Component {
                     ? topicStats.totalHospitalizationsPC
                     : topicStats.totalHospitalizations
                   : <Spinner />,
-                title: `${currentCasePC ? "Hospitalizations per 100,000" : "Hospitalizations"} in ${!onlyNational ? list(currentStates.filter(d => d["ID Geography"] !== "01000US").map(o => o.Geography)) : "the USA"}`,
+                title: `${currentCasePC ? "Hospitalizations per 100,000" : "Total Hospitalizations"} in ${!onlyNational ? list(currentStates.filter(d => d["ID Geography"] !== "01000US").map(o => o.Geography)) : "the USA"}`,
                 subtitle: show ? `as of ${dayFormat(today)}` : ""
               }
             ],
@@ -1517,7 +1517,7 @@ class Coronavirus extends Component {
       const subtitle = show ? `${dayFormat(today)}` : "";
       if (topicStats.totalCurrentlyHospitalized) caseSections.hospitalizations.stat.push({value: topicStats.totalCurrentlyHospitalized, title: `Currently Hospitalized ${titlesuffix}`, subtitle});
       if (topicStats.totalCurrentlyInICU) caseSections.hospitalizations.stat.push({value: topicStats.totalCurrentlyInICU, title: `Currently in ICU ${titlesuffix}`, subtitle});
-      if (topicStats.totalCurrentlyOnVentilator) caseSections.hospitalizations.stat.push({value: topicStats.totalCurrentlyOnVentilator, title: `Currently on Ventilator ${titlesuffix}`, subtitle});
+      if (topicStats.totalCurrentlyOnVentilator) caseSections.hospitalizations.stat.push({value: topicStats.totalCurrentlyOnVentilator, title: `Currently on Ventilator${topicStats.totalCurrentlyOnVentilator !== 1 ? "s" : ""} ${titlesuffix}`, subtitle});
     }
 
     const sparklineBuckets = 20;

--- a/app/pages/Coronavirus.jsx
+++ b/app/pages/Coronavirus.jsx
@@ -1823,7 +1823,7 @@ class Coronavirus extends Component {
                       {
                         Array.isArray(currentSection.stat) ?
                           currentSection.stat.map(stat => (
-                            <div className="StatGroup multiple">
+                            <div className="StatGroup single">
                               <div className="stat-value">{stat.value}</div>
                               <div className="stat-title">{stat.title}</div>
                               <div className="stat-subtitle">{stat.subtitle}</div>

--- a/app/pages/Coronavirus.jsx
+++ b/app/pages/Coronavirus.jsx
@@ -922,7 +922,7 @@ class Coronavirus extends Component {
           ["Date", dateFormat(new Date(d.Date))],
           ["Total Deaths", commas(d.Deaths)]
         ];
-        if (d.DeathsConfirmed !== undefined && d.DeathsProbable !== undefined) {
+        if (d.DeathsConfirmed && d.DeathsProbable) {
           arr.push(["Confirmed Deaths", commas(d.DeathsConfirmed)]);
           arr.push(["Probable Deaths", commas(d.DeathsProbable)]);
         }

--- a/app/pages/Coronavirus.jsx
+++ b/app/pages/Coronavirus.jsx
@@ -96,7 +96,8 @@ const countryMeta = Object.keys(countries).reduce((obj, key) => {
   return obj;
 }, {});
 
-const commas = format(",");
+const d3Commas = format(",");
+const commas = d => d > 999999 ? formatAbbreviate(d) : d3Commas(d);
 
 const suffixes = ["th", "st", "nd", "rd"];
 


### PR DESCRIPTION
Closes #901 

Uses the more advanced and future-proof stats `positiveCasesViral`, `totalTestResults`, and `hospitalizedCumulative` (over `positive`, `tests`, and `hospitalized`) when available. This fixes the strange stutter-gap with MA.

![image](https://user-images.githubusercontent.com/1714292/94959537-5bc78880-04bf-11eb-9add-b29bf885b194.png)

When available, adds new breakout stats, `DeathsConfirmed` and `DeathsProbable`, to the Deaths Tooltip.

![image](https://user-images.githubusercontent.com/1714292/94959714-a0ebba80-04bf-11eb-9505-4729cac0674b.png)

When available, adds new hospitalization stats, `CurrentlyHospitalized`, `CurrentlyInICU`, and `CurrentlyOnVentilator` to the tooltip of the Hospitalizations chart.

![image](https://user-images.githubusercontent.com/1714292/94959758-b7921180-04bf-11eb-8829-3fd43f4f2fc1.png)

Adds `CurrentlyHospitalized` to header table

![image](https://user-images.githubusercontent.com/1714292/94959842-ddb7b180-04bf-11eb-9fa8-7a2b212cf546.png)

And finally, if all selected states have a given "Currently" hospital stat, the present-day stats are shown on the hospital tab:

![image](https://user-images.githubusercontent.com/1714292/94959921-0475e800-04c0-11eb-9bd5-b529e35b3033.png)

@davelandry I need your design help, because if a state (like MA) has all three indicators, the stats are giant/bad: 

![image](https://user-images.githubusercontent.com/1714292/94959990-1d7e9900-04c0-11eb-9718-77583412e4a0.png)
