### PR TITLE
multiple selector fixes

### DIFF
--- a/app/components/Footer/index.css
+++ b/app/components/Footer/index.css
@@ -142,17 +142,17 @@
       }
     }
   }
-}
 
-#datausa {
-  height: 28px;
-  width: 113.42px;
-}
+  & #datausa {
+    height: 28px;
+    width: 113.42px;
+  }
 
-#deloitte {
-  height: 20px;
-}
+  & #deloitte {
+    height: 20px;
+  }
 
-#datawheel {
-  height: 24px;
+  & #datawheel {
+    height: 24px;
+  }
 }

--- a/app/toCanon/Splash.jsx
+++ b/app/toCanon/Splash.jsx
@@ -5,6 +5,7 @@ import Search from "toCanon/Search";
 import "./Splash.css";
 import {Button} from "@blueprintjs/core";
 import SVG from "react-inlinesvg";
+import stripP from "@datawheel/canon-cms/src/utils/formatters/stripP";
 
 class CompareButton extends Component {
 
@@ -78,7 +79,7 @@ class Splash extends Component {
       <Search className="SearchButton"
         icon={ false }
         inactiveComponent={ CompareButton }
-        placeholder={ `Search ${profile.label.replace(/([A-z]$)/g, chr => chr === "y" ? "ies" : `${chr}s`)}` }
+        placeholder={ `Search ${stripP(profile.label).replace(/([A-z]$)/g, chr => chr === "y" ? "ies" : `${chr}s`)}` }
         primary={false}
         resultRender={d => <div onClick={() => addComparison(d.slug || d.id)} className="result-container">
           <SVG className={`result-icon ${d.profile}`} src={ `/icons/dimensions/${d.dimension}.svg` } />

--- a/app/toCanon/topics/Column.jsx
+++ b/app/toCanon/topics/Column.jsx
@@ -16,9 +16,10 @@ class Column extends Component {
 
   onSelector(name, value) {
     const {onSelector, updateSource} = this.context;
+    const {comparison} = this.props.contents;
     this.setState({loading: true});
     if (updateSource) updateSource(false);
-    onSelector(name, value, () => this.setState({loading: false}));
+    onSelector(name, value, comparison, () => this.setState({loading: false}));
   }
 
   render() {
@@ -27,8 +28,9 @@ class Column extends Component {
     const {stripP} = formatters;
     const {contents, sources} = this.props;
     const {loading} = this.state;
-    const {descriptions, selectors, slug, subtitles, title, titleCompare, visualizations} = contents;
+    const {descriptions, slug, subtitles, title, titleCompare, visualizations} = contents;
 
+    const selectors = contents.selectors.filter(selector => selector.options.length > 1);
     const hideText = router.location.query.viz === "true";
 
     return <div className={ `topic ${slug} Column ${loading ? "topic-loading" : ""}` }>

--- a/app/toCanon/topics/TextViz.jsx
+++ b/app/toCanon/topics/TextViz.jsx
@@ -19,9 +19,10 @@ class TextViz extends Component {
 
   onSelector(name, value) {
     const {onSelector, updateSource} = this.context;
+    const {comparison} = this.props.contents;
     this.setState({loading: true});
     if (updateSource) updateSource(false);
-    onSelector(name, value, () => this.setState({loading: false}));
+    onSelector(name, value, comparison, () => this.setState({loading: false}));
   }
 
   render() {
@@ -29,10 +30,11 @@ class TextViz extends Component {
     const {stripP} = formatters;
     const {contents, sources} = this.props;
     const {loading} = this.state;
-    const {descriptions, selectors, slug, stats, subtitles, title, titleCompare, visualizations} = contents;
+    const {descriptions, slug, stats, subtitles, title, titleCompare, visualizations} = contents;
 
     const miniviz = visualizations.length > 1 ? visualizations[0] : false;
     const mainviz = visualizations.length > 1 ? visualizations.slice(1) : visualizations;
+    const selectors = contents.selectors.filter(selector => selector.options.length > 1);
 
     if (router.location.query.viz === "true") {
       return <div className={ `topic ${slug || ""} Column ${loading ? "topic-loading" : ""}` }>


### PR DESCRIPTION
- fixes selectors not working in some cases by porting over relevant code from the canon-cms ProfileRenderer: https://github.com/Datawheel/canon/blob/master/packages/cms/src/components/ProfileRenderer.jsx
- enables selector values in URL
- fixes selectors in comparison mode
- hides selectors if they only have 1 option
- removes `<p>` tags from being visible in comparison search placeholder
- fixes Footer logo CSS conflicting with Home splash logos

Closes #1003